### PR TITLE
Quality improvements

### DIFF
--- a/.idea/egs-api.iml
+++ b/.idea/egs-api.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="CPP_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/examples" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/egs-api.iml" filepath="$PROJECT_DIR$/.idea/egs-api.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,206 @@
+# PROJECT KNOWLEDGE BASE
+
+**Generated:** 2026-02-15
+**Commit:** b552708 (uncommitted changes on top)
+**Branch:** master
+
+## OVERVIEW
+
+Async Rust client library for the Epic Games Store API. Provides authentication, asset listing, download manifest parsing (binary + JSON), and Fab marketplace integration via `reqwest`/`tokio`.
+
+## STRUCTURE
+
+```
+egs-api/
+├── src/
+│   ├── lib.rs                    # Public facade: EpicGames struct + facade_tests
+│   └── api/
+│       ├── mod.rs                # Internal EpicAPI struct + HTTP helpers (authorized_get_json, etc.)
+│       ├── login.rs              # OAuth session: start, resume, invalidate
+│       ├── egs.rs                # EGS methods: assets, manifests, library (uses HTTP helpers)
+│       ├── account.rs            # Account details, friends, entitlements (uses HTTP helpers)
+│       ├── fab.rs                # Fab marketplace: manifests, library (partial helper use)
+│       ├── error.rs              # EpicAPIError enum + tests
+│       ├── utils.rs              # Binary parsing helpers + tests (24 tests)
+│       └── types/
+│           ├── download_manifest.rs  # Binary manifest parser/serializer + tests (12 tests)
+│           ├── account.rs            # UserData (session state), AccountData + tests (6 tests)
+│           ├── asset_info.rs         # AssetInfo with release sorting + tests (9 tests)
+│           ├── fab_library.rs        # FabLibrary with pagination cursors
+│           ├── fab_asset_manifest.rs # Fab download info + distribution points + tests (3 tests)
+│           ├── chunk.rs              # Downloaded chunk with decompression + tests (4 tests)
+│           ├── asset_manifest.rs     # AssetManifest with URL CSV parsing
+│           ├── epic_asset.rs         # EpicAsset (catalog item reference)
+│           ├── library.rs            # Library with pagination metadata
+│           ├── entitlement.rs        # Entitlement record
+│           └── friends.rs            # Friend record
+├── examples/
+│   ├── common.rs                 # Shared auth helper (token persistence at ~/.egs-api/token.json)
+│   ├── auth.rs                   # Interactive login + token persistence
+│   ├── account.rs                # Account details, ID lookup, friends
+│   ├── entitlements.rs           # List all entitlements
+│   ├── library.rs                # Paginated library listing
+│   ├── assets.rs                 # Full pipeline: list → info → manifest → download manifest
+│   ├── game_token.rs             # Exchange code + ownership token (Fortnite hardcoded)
+│   ├── fab.rs                    # Fab library → asset manifest → download manifest
+│   └── workflow.rs               # Original auth flow demo (pre-existing)
+├── Cargo.toml                    # v0.8.1, edition 2018, MIT, autoexamples=false
+├── README.md                     # Comprehensive docs with badges, auth flow, endpoint tables
+└── .github/workflows/rust.yml    # CI: cargo build --lib && cargo test --tests --lib
+```
+
+## WHERE TO LOOK
+
+| Task | Location | Notes |
+|------|----------|-------|
+| Add new API endpoint | `src/api/egs.rs` or new file in `src/api/` | Impl block on `EpicAPI`, expose via `lib.rs` |
+| Add new Fab endpoint | `src/api/fab.rs` | Same pattern as `fab_asset_manifest` |
+| Add response type | `src/api/types/` | New file + re-export in `types/mod.rs` |
+| Fix auth/session bugs | `src/api/login.rs` | OAuth token flow, refresh logic |
+| Fix manifest parsing | `src/api/types/download_manifest.rs` | Binary format: header → meta → chunks → files → custom fields |
+| Add public API method | `src/lib.rs` | Thin wrapper delegating to `self.egs.*` |
+| Add tests | Same file as code, `#[cfg(test)] mod tests` | 68 tests across 8 files currently |
+| Modify HTTP headers | `src/api/mod.rs` → constructor in `new()` | User-Agent, Correlation-ID |
+| Add HTTP endpoint | `src/api/mod.rs` helpers | Use `authorized_get_json`, `authorized_post_form_json`, `get_bytes` |
+| Add examples | `examples/` + `Cargo.toml` `[[example]]` | Must use `#[path = "common.rs"] mod common;` pattern |
+
+## ARCHITECTURE
+
+**Facade pattern**: `EpicGames` (public) wraps `EpicAPI` (pub(crate)).
+
+- `EpicGames` in `lib.rs` — consumer-facing, returns `Option`/`Vec` (swallows errors), Fab methods return `Result`
+- `EpicAPI` in `api/mod.rs` — internal, returns `Result<T, EpicAPIError>`
+- API methods split across files via `impl EpicAPI` blocks in `login.rs`, `egs.rs`, `account.rs`, `fab.rs`
+
+**HTTP client**: Single `reqwest::Client` built in `EpicAPI::new()` with cookie store, reused across all requests. Authorization via bearer token in `set_authorization_header()`.
+
+**HTTP helpers** (on `EpicAPI`):
+- `authorized_get_json<T>(&self, url)` — authorized GET → deserialize JSON
+- `authorized_post_form_json<T>(&self, url, form)` — authorized POST with form data → deserialize JSON
+- `get_bytes(&self, url)` — unauthenticated GET → raw bytes
+
+**Auth flow**: `start_session()` → exchange/auth code/refresh token → `handle_login_response()` → updates `UserData`. Session resume via `/oauth/verify`. 600-second expiry threshold for re-login.
+
+## CONVENTIONS
+
+- `#![deny(missing_docs)]` — all public items require doc comments
+- `#![cfg_attr(test, deny(warnings))]` — zero warnings in test builds
+- `#[allow(missing_docs)]` on type structs with many fields
+- `#[serde(rename_all = "camelCase")]` for JSON API responses
+- `#[serde(rename_all = "PascalCase")]` for Epic's manifest format
+- Custom serde deserializers for Epic's blob number format (`deserialize_epic_string`, `deserialize_epic_hash`)
+- Error handling: API methods return `Result<T, EpicAPIError>`, facade methods return `Option<T>`
+- No external test framework — inline `#[cfg(test)]` modules only
+- Edition 2018 — no 2021+ features
+- Manual `impl Default` for `EpicAPI` and `EpicGames` (delegates to `new()` for proper HTTP client init)
+- Examples use `#[path = "common.rs"] mod common;` for shared auth (Cargo limitation)
+- Token persistence: `~/.egs-api/token.json` (UserData serialized as JSON)
+
+## ANTI-PATTERNS (THIS PROJECT)
+
+- **Do not add `as any` equivalents** — no `unsafe` blocks exist, keep it that way
+- **Do not change the User-Agent string** — Epic API may reject non-launcher user agents
+- **5 TODOs in `download_manifest.rs`**: chunk ordering (line ~781), wrong uncompressed size (line ~807, known bug), 3x unknown Epic format fields (lines ~857, ~871, ~875)
+- **Hardcoded credentials**: client_id/secret in `login.rs` (`34a02cf8f4414e29b15921876da36f9a`), correlation ID in `mod.rs` — these are Epic's public launcher credentials, not secrets
+- **No async tests** — despite all API methods being async
+- **`invalidate_sesion`** — typo in method name (missing 's'), preserved for API compat
+
+## TEST SUITE
+
+68 tests, all passing. Run: `cargo test --tests --lib`
+
+| File | Tests | Coverage |
+|------|-------|---------|
+| `utils.rs` | 24 | `blob_to_num`, `bigblob_to_num`, `read_le` (all sizes), `read_fstring` (UTF-8/16/edge cases), `write_fstring`, `decode_hex`, `do_vecs_match` |
+| `download_manifest.rs` | 12 | Binary round-trip (`from_vec` → `to_vec` → `from_vec`), `parse()` fallback (invalid binary/JSON), `chunk_dir()` version thresholds, custom fields get/set, `total_download_size`, `total_size`, `FileManifestList::size()` |
+| `asset_info.rs` | 9 | `latest_release`, `sorted_releases`, `release_info(id)`, `release_name`, `compatible_apps` (dedup), `platforms` (aggregate), None cases |
+| `error.rs` | 8 | `Display` for all 6 variants, `Error::description()`, `Debug` |
+| `lib.rs` (facade_tests) | 7 | `new()`, `Default`, `user_details`, `set_user_details`, `is_logged_in` expired/valid/600s-threshold |
+| `account.rs` | 6 | `UserData::new()` defaults, `update()` partial-merge (merges/preserves), serialization round-trip, access/refresh token getters |
+| `chunk.rs` | 4 | `from_vec` valid uncompressed, valid compressed (zlib), wrong magic, version 2 SHA hash |
+| `fab_asset_manifest.rs` | 3 | `get_distribution_point_by_base_url` found/not-found/empty |
+
+## BINARY MANIFEST FORMAT
+
+`download_manifest.rs` is the complexity hotspot. Binary format (little-endian):
+
+```
+Header (41 bytes): magic(u32) → header_size(u32) → size_uncompressed(u32) → size_compressed(u32) → sha_hash(20 bytes) → compressed(u8) → version(u32)
+Body (zlib-compressed):
+  Meta: data_version → manifest_version → is_file_data → app_id → strings...
+  Chunks: version → count → [guid(16b) × N] → [hash(u64) × N] → [sha(20b) × N] → [group(u8) × N] → [window(u32) × N] → [filesize(i64) × N]
+  Files: version → count → [filename × N] → [symlink × N] → [hash(20b) × N] → [flags(u8) × N] → [tags × N] → [chunk_parts × N]
+  Custom Fields: version → count → [keys × N] → [values × N]
+```
+
+Parsing uses position-tracking via `&mut usize` with helpers in `utils.rs` (`read_le`, `read_fstring`, etc.).
+
+## COMMANDS
+
+```bash
+cargo build --lib              # Build library
+cargo test --tests --lib       # Run tests (CI command) — 68 tests
+cargo build --examples         # Build all examples
+cargo run --example auth       # Interactive auth demo (opens browser)
+cargo doc --open               # Generate + view docs (may fail on recent toolchains)
+```
+
+## COMPLETED WORK (this session)
+
+All changes are uncommitted, sitting on top of commit b552708.
+
+### HTTP & Architecture
+- Extracted HTTP helpers in `src/api/mod.rs`: `authorized_get_json<T>`, `authorized_post_form_json<T>`, `get_bytes`
+- Inlined `build_client()` — constructor logic now directly in `new()`; single `self.client` reused everywhere
+- Refactored callers: `egs.rs` (7 methods), `account.rs` (4 methods), `fab.rs` (2 of 3), `login.rs` (1 method)
+- Fixed `Default` derive: Manual `impl Default` for `EpicAPI` and `EpicGames` delegating to `new()`
+
+### Bug Fixes
+- `to_vec()` panic on `chunk_sha_list: None` → `unwrap_or(&HashMap::new())`
+- `to_vec()` truncation via `files.resize()` → `for _ { files.push(0u8) }`
+- Dangerous unwraps: Zlib decompression and SHA hash conversions → graceful `return None`
+
+### Examples (8 new + shared auth)
+- `common.rs` (shared auth), `auth.rs`, `account.rs`, `entitlements.rs`, `library.rs`, `assets.rs`, `game_token.rs`, `fab.rs`
+- All verified against live Epic Games API (100% pass rate)
+- `Cargo.toml`: `autoexamples = false`, 8 explicit `[[example]]` entries
+
+### Documentation
+- README.md: Complete rewrite with badges, features, quick start, auth flow, endpoint tables, manifest format, architecture
+- Cargo.toml: Added `keywords`, `categories`, `readme = "README.md"`
+- `src/lib.rs`: Comprehensive `//!` crate-level docs with code example, enhanced struct/method docs
+- Internal docs: Doc comments on all API methods and type definitions
+
+### Test Suite (10 → 68 tests)
+- `utils.rs` +14, `download_manifest.rs` +12, `chunk.rs` +4, `account.rs` +6
+- `asset_info.rs` +9, `fab_asset_manifest.rs` +3, `error.rs` +8, `lib.rs` +7
+
+## REMAINING BACKLOG
+
+From `thoughts/shared/designs/2026-02-14-api-quality-improvements-design.md`, items 6-12:
+
+| # | Improvement | Effort | Notes |
+|---|------------|--------|-------|
+| 6 | Decompose `download_manifest.rs` | High | Split `from_vec()`/`to_vec()` into `parse_header/meta/chunks/files/custom_fields` |
+| 7 | Enrich `EpicAPIError` with source errors | Medium | Add `NetworkError(reqwest::Error)`, `HttpError { status, body }` — **semver-breaking** |
+| 8 | Add `BinaryReader`/`BinaryWriter` abstraction | Medium | Bounds-checked reads, replaces raw `buffer[position]` indexing |
+| 9 | Add `Result`-returning facade methods | Medium | New `try_*` methods on `EpicGames` alongside `Option`-returning ones |
+| 11 | Reduce `.clone()` usage | Low | `&EpicAsset` instead of owned, iterate by reference |
+| 12 | Add async integration tests | Medium | Would need mock HTTP server (e.g., `wiremock`) |
+
+Items 10 (Default fix) and partial item 12 (sync tests) are already done.
+
+## NOTES
+
+- Published to crates.io as `egs-api`; docs at docs.rs/egs-api
+- CI uses `actions/checkout@v2` (outdated) with no clippy/rustfmt/audit steps
+- Fab API returns 403 on timeout → mapped to `EpicAPIError::FabTimeout`
+- `UserData::update()` merges only `Some` fields — partial update pattern for token refresh
+- `download_manifest.rs` supports both JSON and binary manifest formats; `parse()` tries binary first, falls back to JSON
+- Pagination: `library_items` and `fab_library_items` use cursor-based loops
+- `serde_with::DefaultOnNull` used in `fab_library.rs` to handle null arrays from API
+- `fab_asset_manifest` kept lower-level (not using HTTP helpers) due to special 403→FabTimeout handling
+- `game_token.rs` example has hardcoded Fortnite values: namespace `"fn"`, catalog_item `"4fe75bbc5a674f4f9b356b5c90567da5"`
+- `cargo doc` may fail on recent Rust toolchains (1.93+) due to template engine bug — not our issue
+- Auth URL: `https://www.epicgames.com/id/api/redirect?clientId=34a02cf8f4414e29b15921876da36f9a&responseType=code`
+- Token file: `~/.egs-api/token.json` (UserData serialized as JSON)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,78 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.9.0] - 2026-02-15
+
+### Breaking Changes
+
+- **`EpicAPIError::Unknown` removed** — replaced by three typed variants that
+  preserve error context:
+  - `NetworkError(reqwest::Error)` — transport/connection failures
+  - `DeserializationError(String)` — response body parse failures
+  - `HttpError { status, body }` — non-success HTTP status codes
+
+  **Migration:** replace any `EpicAPIError::Unknown` match arms with the new
+  variants, or use a wildcard `_` arm if you don't need to distinguish them.
+
+- **`DownloadManifest::from_vec` signature changed** — now takes `&[u8]` instead
+  of `Vec<u8>`. Pass a slice reference instead of an owned `Vec`.
+
+- **`DownloadManifest::set_custom_field` signature changed** — now takes
+  `(&str, &str)` instead of `(String, String)`.
+
+- **`EpicGames::asset_info` signature changed** — now takes `&EpicAsset`
+  instead of `EpicAsset`.
+
+- **`EpicGames::ownership_token` signature changed** — now takes `&EpicAsset`
+  instead of `EpicAsset`.
+
+- **`UserData::access_token` and `refresh_token` return types changed** —
+  now return `Option<&str>` instead of `Option<String>`.
+
+- **`write_fstring` signature changed** — now takes `&str` instead of `String`.
+
+### Added
+
+- `EpicAPIError` now implements `From<reqwest::Error>` for ergonomic `?` usage.
+- `try_asset_info`, `try_account_details`, `try_account_friends`,
+  `try_user_entitlements`, `try_library_items`, `try_list_assets`,
+  `try_game_token` — `Result`-returning facade methods on `EpicGames` that
+  expose errors instead of swallowing them.
+- `BinaryReader` / `BinaryWriter` — internal bounds-checked binary I/O
+  abstraction for manifest parsing.
+- 14 new API endpoints: `catalog_items`, `catalog_offers`,
+  `bulk_catalog_items`, `currencies`, `library_state_token_status`,
+  `service_status`, `offer_prices`, `quick_purchase`, `billing_account`,
+  `update_presence`, `external_auths`, `sso_domains`,
+  `fab_file_download_info`, `auth_client_credentials`.
+- 13 new examples covering all endpoints.
+- Comprehensive test suite (10 → 87 tests).
+- Doc comments on all public types and API methods.
+- Complete README rewrite with auth flow, endpoint tables, and architecture.
+
+### Fixed
+
+- `DownloadManifest::to_vec()` panic when `chunk_sha_list` is `None`.
+- `DownloadManifest::to_vec()` buffer truncation caused by `files.resize()`.
+- Dangerous `unwrap()` calls replaced with graceful error handling across
+  manifest parsing, zlib decompression, and SHA hash conversion.
+- HTTP client now reused across requests (was rebuilt per-request, defeating
+  connection pooling).
+
+### Changed
+
+- Internal HTTP boilerplate extracted into shared helper methods.
+- `download_manifest.rs` decomposed from monolithic parser into named section
+  helpers (`parse_header`, `parse_meta`, `parse_chunks`, `parse_files`,
+  `parse_custom_fields`).
+- Reduced `.clone()` usage across the crate — methods take references where
+  possible.
+
+## [0.8.1] - Previous release
+
+See [GitHub releases](https://github.com/AchetaGames/egs-api-rs/releases) for
+prior history.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/AchetaGames/egs-api-rs"
 documentation = "https://docs.rs/egs-api/latest/egs_api/"
-edition = "2018"
+edition = "2021"
 rust-version = "1.82"
 autoexamples = false
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,17 +3,18 @@ name = "egs-api"
 version = "0.9.0"
 authors = ["Milan Šťastný <milan@acheta.games>"]
 description = "Interface to the Epic Games API"
-categories = ["asynchronous"]
-keywords = ["EpicGames", "Epic", "egs"]
+categories = ["api-bindings", "asynchronous", "games"]
+keywords = ["EpicGames", "Epic", "egs", "game-store", "marketplace"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/AchetaGames/egs-api-rs"
 documentation = "https://docs.rs/egs-api/latest/egs_api/"
 edition = "2018"
+rust-version = "1.82"
 autoexamples = false
 
 [dependencies]
-reqwest = { version = "0.12", features = ["json", "cookies", "blocking"] }
+reqwest = { version = "0.12", features = ["json", "cookies"] }
 serde_json = "1.0"
 serde_with = "3"
 url = { version = "2.5", features = ["serde"] }
@@ -38,6 +39,7 @@ features = ["derive"]
 [dev-dependencies]
 webbrowser = "1"
 env_logger = "0.11"
+reqwest = { version = "0.12", features = ["blocking"] }
 
 [[example]]
 name = "workflow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egs-api"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Milan Šťastný <milan@acheta.games>"]
 description = "Interface to the Epic Games API"
 categories = ["asynchronous"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 repository = "https://github.com/AchetaGames/egs-api-rs"
 documentation = "https://docs.rs/egs-api/latest/egs_api/"
 edition = "2018"
+autoexamples = false
 
 [dependencies]
 reqwest = { version = "0.12", features = ["json", "cookies", "blocking"] }
@@ -37,3 +38,55 @@ features = ["derive"]
 [dev-dependencies]
 webbrowser = "1"
 env_logger = "0.11"
+
+[[example]]
+name = "workflow"
+path = "examples/workflow.rs"
+
+[[example]]
+name = "auth"
+path = "examples/auth.rs"
+
+[[example]]
+name = "account"
+path = "examples/account.rs"
+
+[[example]]
+name = "entitlements"
+path = "examples/entitlements.rs"
+
+[[example]]
+name = "library"
+path = "examples/library.rs"
+
+[[example]]
+name = "assets"
+path = "examples/assets.rs"
+
+[[example]]
+name = "game_token"
+path = "examples/game_token.rs"
+
+[[example]]
+name = "fab"
+path = "examples/fab.rs"
+
+[[example]]
+name = "catalog"
+path = "examples/catalog.rs"
+
+[[example]]
+name = "commerce"
+path = "examples/commerce.rs"
+
+[[example]]
+name = "status"
+path = "examples/status.rs"
+
+[[example]]
+name = "presence"
+path = "examples/presence.rs"
+
+[[example]]
+name = "client_credentials"
+path = "examples/client_credentials.rs"

--- a/README.md
+++ b/README.md
@@ -11,18 +11,218 @@
 
 # egs-api
 
-A minimal asynchronous interface to Epic Games Store
+Async Rust client for the Epic Games Store API. Handles authentication, asset
+management, download manifest parsing (binary + JSON), and
+[Fab](https://www.fab.com/) marketplace integration.
 
-See example for how to use
+Built on `reqwest` / `tokio`.
 
-## Current functionality
+## Features
 
-- Authentication
-- Listing Assets
-- Get Asset metadata
-- Get Asset info
-- Get Ownership Token
-- Get Game Token
-- Get Entitlements
-- Get Library Items
-- Generate download links for chunks
+- **Authentication** — OAuth login via authorization code, exchange token, or
+  refresh token. Session resume and invalidation.
+- **Assets** — List owned assets, fetch catalog metadata (including DLC trees),
+  retrieve asset manifests with CDN download URLs.
+- **Download Manifests** — Parse Epic's binary and JSON manifest formats.
+  Exposes file lists, chunk hashes, and custom fields needed to reconstruct
+  downloads.
+- **Fab Marketplace** — List Fab library items, fetch Fab asset manifests with
+  signed distribution points, and download Fab manifests.
+- **Account** — Account details, bulk account ID lookup, friends list
+  (including pending requests).
+- **Entitlements** — Query all user entitlements (games, DLC, subscriptions).
+- **Library** — Paginated library listing with optional metadata.
+- **Tokens** — Game exchange tokens and per-asset ownership tokens (JWT).
+
+## Quick Start
+
+Add to `Cargo.toml`:
+
+```toml
+[dependencies]
+egs-api = "0.8"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+```
+
+```rust
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    let mut egs = EpicGames::new();
+
+    // Authenticate with an authorization code obtained from:
+    // https://www.epicgames.com/id/api/redirect?clientId=34a02cf8f4414e29b15921876da36f9a&responseType=code
+    let code = "your_authorization_code".to_string();
+    if egs.auth_code(None, Some(code)).await {
+        println!("Logged in as {}", egs.user_details().display_name.unwrap_or_default());
+    }
+
+    // List all owned assets
+    let assets = egs.list_assets(None, None).await;
+    println!("You own {} assets", assets.len());
+
+    // Get detailed info for the first asset
+    if let Some(asset) = assets.first() {
+        if let Some(info) = egs.asset_info(asset.clone()).await {
+            println!("{}: {}", info.id, info.title.unwrap_or_default());
+        }
+    }
+}
+```
+
+## Authentication Flow
+
+Epic uses OAuth2 with a launcher client ID. The typical flow is:
+
+1. Open the authorization URL in a browser — the user logs in and is redirected
+   to a JSON page containing an `authorizationCode`.
+2. Pass that code to `egs.auth_code(None, Some(code))`.
+3. On success, `egs.user_details()` contains the session tokens.
+
+To persist the session across runs, serialize `egs.user_details()` (it
+implements `Serialize` / `Deserialize`) and restore it later with
+`egs.set_user_details(saved)` followed by `egs.login()` which will use the
+refresh token to re-authenticate.
+
+**Authorization URL:**
+```
+https://www.epicgames.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D34a02cf8f4414e29b15921876da36f9a%26responseType%3Dcode
+```
+
+See the [`auth`](examples/auth.rs) example for a complete interactive flow with
+token persistence.
+
+## Examples
+
+The crate ships with examples covering every endpoint. Run them with:
+
+```bash
+# First: authenticate and save a token
+cargo run --example auth
+
+# Then run any of these (they reuse the saved token):
+cargo run --example account              # Account details, ID lookup, friends, external auths, SSO
+cargo run --example entitlements         # List all entitlements
+cargo run --example library              # Paginated library listing
+cargo run --example assets               # Full pipeline: list → info → manifest → download manifest
+cargo run --example game_token           # Exchange code + ownership token
+cargo run --example fab                  # Fab library → asset manifest → download manifest
+cargo run --example catalog              # Catalog items, offers, bulk lookup
+cargo run --example commerce             # Currencies, prices, billing, quick purchase
+cargo run --example status               # Service status (lightswitch API)
+cargo run --example presence             # Update online presence
+cargo run --example client_credentials   # App-level auth + library state tokens
+```
+
+## API Overview
+
+The public API is the [`EpicGames`](https://docs.rs/egs-api/latest/egs_api/struct.EpicGames.html)
+struct. It wraps an internal HTTP client with cookie storage and bearer token
+management. Most methods return `Option<T>` or `Vec<T>` (swallowing transport
+errors); Fab methods return `Result<T, EpicAPIError>` to expose timeout/error
+distinctions.
+
+### Authentication
+
+| Method | Description |
+|--------|-------------|
+| `auth_code(exchange_token, authorization_code)` | Start a new session |
+| `auth_client_credentials()` | App-level auth (no user context) |
+| `login()` | Resume session using saved refresh token |
+| `logout()` | Invalidate current session |
+| `is_logged_in()` | Check if access token is still valid (>600s remaining) |
+| `user_details()` / `set_user_details(data)` | Get/set session state for persistence |
+
+### Epic Games Store
+
+| Method | Description |
+|--------|-------------|
+| `list_assets(platform, label)` | List all owned assets (default: Windows/Live) |
+| `asset_info(asset)` | Catalog metadata for an asset (includes DLC list) |
+| `asset_manifest(platform, label, namespace, item_id, app)` | CDN manifest with download URLs |
+| `asset_download_manifests(manifest)` | Parse binary/JSON download manifests from all CDN mirrors |
+| `catalog_items(namespace, start, count)` | Paginated catalog items for a namespace |
+| `catalog_offers(namespace, start, count)` | Paginated catalog offers for a namespace |
+| `bulk_catalog_items(items)` | Bulk fetch catalog items across namespaces |
+| `currencies(start, count)` | Available currencies with symbols and decimals |
+| `game_token()` | Short-lived exchange code for game launches |
+| `ownership_token(asset)` | JWT proving asset ownership |
+| `library_state_token_status(token_id)` | Check library state token validity |
+
+### Fab Marketplace
+
+| Method | Description |
+|--------|-------------|
+| `fab_library_items(account_id)` | List all Fab library items (paginated) |
+| `fab_asset_manifest(artifact_id, namespace, asset_id, platform)` | Signed download info with distribution points |
+| `fab_download_manifest(download_info, distribution_point_url)` | Parse download manifest from a specific CDN |
+| `fab_file_download_info(listing_id, format_id, file_id)` | Download info for a specific Fab file |
+
+### Account & Social
+
+| Method | Description |
+|--------|-------------|
+| `account_details()` | Email, display name, country, 2FA status |
+| `account_ids_details(ids)` | Bulk lookup of account IDs to display names |
+| `account_friends(include_pending)` | Friends list with pending request status |
+| `external_auths(account_id)` | Linked platform accounts (Steam, PSN, Xbox, etc.) |
+| `sso_domains()` | SSO domain list for cookie sharing |
+| `user_entitlements()` | All entitlements (games, DLC, subscriptions) |
+| `library_items(include_metadata)` | Library records with optional metadata |
+
+### Commerce
+
+| Method | Description |
+|--------|-------------|
+| `offer_prices(namespace, offer_ids, country)` | Offer pricing with formatted strings |
+| `quick_purchase(namespace, offer_id)` | Quick purchase (free game claims) |
+| `billing_account()` | Default billing account and country |
+
+### Status & Presence
+
+| Method | Description |
+|--------|-------------|
+| `service_status(service_id)` | Service operational status (lightswitch API) |
+| `update_presence(session_id, body)` | Update user online presence |
+
+## Download Manifest Format
+
+The [`DownloadManifest`](https://docs.rs/egs-api/latest/egs_api/api/types/download_manifest/struct.DownloadManifest.html)
+struct handles Epic's binary manifest format (with JSON fallback). The binary
+format is little-endian, optionally zlib-compressed:
+
+```
+Header (41 bytes):
+  magic(u32) → header_size(u32) → size_uncompressed(u32) →
+  size_compressed(u32) → sha_hash(20 bytes) → compressed(u8) → version(u32)
+
+Body (zlib-compressed):
+  Meta:   feature_level, is_file_data, app_id, app_name, build_version, launch_exe, ...
+  Chunks: guid(16 bytes) × N, hash(u64) × N, sha(20 bytes) × N, group(u8) × N, ...
+  Files:  filename × N, symlink_target × N, sha_hash(20 bytes) × N, install_tags × N, chunk_parts × N
+  Custom: key-value pairs (e.g., BaseUrl, CatalogItemId, BuildLabel)
+```
+
+Use `DownloadManifest::parse(data)` to parse either format. Access file lists
+via `file_manifest_list`, chunk info via `chunk_hash_list`, and custom fields
+via `custom_field(key)`.
+
+## Architecture
+
+```
+EpicGames (public facade, src/lib.rs)
+  └── EpicAPI (internal, src/api/mod.rs)
+        ├── login.rs    — OAuth: start, resume, invalidate
+        ├── egs.rs      — Assets, manifests, library, tokens
+        ├── account.rs  — Account details, friends, entitlements
+        └── fab.rs      — Fab marketplace integration
+```
+
+`EpicGames` is the consumer-facing struct. It delegates to `EpicAPI` which
+holds the `reqwest::Client` (with cookie store) and `UserData` (session state).
+API methods are split across files via `impl EpicAPI` blocks.
+
+## License
+
+MIT

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-egs-api = "0.8"
+egs-api = "0.9"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ async fn main() {
 
     // Get detailed info for the first asset
     if let Some(asset) = assets.first() {
-        if let Some(info) = egs.asset_info(asset.clone()).await {
+        if let Some(info) = egs.asset_info(asset).await {
             println!("{}: {}", info.id, info.title.unwrap_or_default());
         }
     }

--- a/examples/account.rs
+++ b/examples/account.rs
@@ -1,0 +1,88 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Account Details ===\n");
+
+    match egs.account_details().await {
+        Some(details) => {
+            println!("Display Name: {}", details.display_name);
+            println!("Email: {}", details.email);
+            println!("Country: {}", details.country);
+            println!("2FA Enabled: {}", details.tfa_enabled);
+            println!("Last Login: {}", details.last_login);
+        }
+        None => eprintln!("Failed to fetch account details"),
+    }
+
+    println!("\n=== Account ID Lookup ===\n");
+
+    let account_id = egs.user_details().account_id.unwrap_or_default();
+    if !account_id.is_empty() {
+        match egs.account_ids_details(vec![account_id.clone()]).await {
+            Some(infos) => {
+                for info in &infos {
+                    println!("ID: {} -> Display Name: {}", info.id, info.display_name);
+                }
+            }
+            None => eprintln!("Failed to fetch account info"),
+        }
+    }
+
+    println!("\n=== Friends List ===\n");
+
+    match egs.account_friends(true).await {
+        Some(friends) => {
+            println!("Total friends (including pending): {}", friends.len());
+            for friend in friends.iter().take(10) {
+                println!("  {:?}", friend);
+            }
+            if friends.len() > 10 {
+                println!("  ... and {} more", friends.len() - 10);
+            }
+        }
+        None => eprintln!("Failed to fetch friends list"),
+    }
+
+    println!("\n=== External Auth Connections ===\n");
+
+    match egs.external_auths(&account_id).await {
+        Some(auths) => {
+            println!("Linked platforms: {}", auths.len());
+            for auth in &auths {
+                println!(
+                    "  {} - {}",
+                    auth.type_field,
+                    auth.external_display_name
+                );
+            }
+        }
+        None => eprintln!("Failed to fetch external auth connections"),
+    }
+
+    println!("\n=== SSO Domains ===\n");
+
+    match egs.sso_domains().await {
+        Some(domains) => {
+            println!("SSO domains: {}", domains.len());
+            for domain in domains.iter().take(20) {
+                println!("  {}", domain);
+            }
+            if domains.len() > 20 {
+                println!("  ... and {} more", domains.len() - 20);
+            }
+        }
+        None => eprintln!("Failed to fetch SSO domains"),
+    }
+}

--- a/examples/assets.rs
+++ b/examples/assets.rs
@@ -27,7 +27,7 @@ async fn main() {
     }
 
     let test_asset = match assets.first() {
-        Some(a) => a.clone(),
+        Some(a) => a,
         None => {
             println!("No assets found, nothing more to demo.");
             return;
@@ -36,7 +36,7 @@ async fn main() {
 
     println!("\n=== Asset Info (first asset) ===\n");
 
-    match egs.asset_info(test_asset.clone()).await {
+    match egs.asset_info(test_asset).await {
         Some(info) => println!("{:#?}", info),
         None => eprintln!("Failed to fetch asset info for {}", test_asset.app_name),
     }

--- a/examples/assets.rs
+++ b/examples/assets.rs
@@ -1,0 +1,79 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== List Assets ===\n");
+
+    let assets = egs.list_assets(None, None).await;
+    println!("Total assets: {}", assets.len());
+
+    let sample = assets.iter().take(5).collect::<Vec<_>>();
+    for asset in &sample {
+        println!(
+            "  {} (namespace: {}, catalog: {})",
+            asset.app_name, asset.namespace, asset.catalog_item_id
+        );
+    }
+
+    let test_asset = match assets.first() {
+        Some(a) => a.clone(),
+        None => {
+            println!("No assets found, nothing more to demo.");
+            return;
+        }
+    };
+
+    println!("\n=== Asset Info (first asset) ===\n");
+
+    match egs.asset_info(test_asset.clone()).await {
+        Some(info) => println!("{:#?}", info),
+        None => eprintln!("Failed to fetch asset info for {}", test_asset.app_name),
+    }
+
+    println!("\n=== Asset Manifest ===\n");
+
+    let manifest = egs
+        .asset_manifest(
+            None,
+            None,
+            Some(test_asset.namespace.clone()),
+            Some(test_asset.catalog_item_id.clone()),
+            Some(test_asset.app_name.clone()),
+        )
+        .await;
+
+    match manifest {
+        Some(m) => {
+            println!("Manifest elements: {}", m.elements.len());
+            println!("{:#?}", m);
+
+            println!("\n=== Download Manifests ===\n");
+
+            let download_manifests = egs.asset_download_manifests(m).await;
+            println!("Got {} download manifest(s)", download_manifests.len());
+            for dm in &download_manifests {
+                println!(
+                    "  App: {} | Files: {} | Chunks: {}",
+                    dm.app_name_string,
+                    dm.file_manifest_list.len(),
+                    dm.chunk_hash_list.len()
+                );
+            }
+        }
+        None => eprintln!(
+            "Failed to fetch asset manifest for {}",
+            test_asset.app_name
+        ),
+    }
+}

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -1,0 +1,30 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    println!("=== Authentication Example ===\n");
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed");
+        std::process::exit(1);
+    }
+
+    let details = egs.user_details();
+    println!("\nLogged in as: {}", details.display_name.unwrap_or_default());
+    println!("Account ID: {}", details.account_id.unwrap_or_default());
+
+    println!("\nToken saved. Run other examples without re-authenticating.");
+    println!("To logout, uncomment the logout section below.\n");
+
+    // Uncomment to invalidate the session and delete the saved token:
+    // if egs.logout().await {
+    //     println!("Logged out successfully");
+    //     let _ = std::fs::remove_file(dirs_or_home().join(".egs-api/token.json"));
+    // }
+}

--- a/examples/catalog.rs
+++ b/examples/catalog.rs
@@ -1,0 +1,86 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Catalog Items ===\n");
+
+    let namespace = "fn";
+    match egs.catalog_items(namespace, 0, 10).await {
+        Some(page) => {
+            if let Some(paging) = &page.paging {
+                println!("Total items in '{}': {}", namespace, paging.total);
+            }
+            for item in &page.elements {
+                println!(
+                    "  [{}] {} (type: {})",
+                    item.id,
+                    item.title.as_deref().unwrap_or("(untitled)"),
+                    item.item_type.as_deref().unwrap_or("unknown"),
+                );
+            }
+        }
+        None => eprintln!("Failed to fetch catalog items for '{}'", namespace),
+    }
+
+    println!("\n=== Catalog Offers ===\n");
+
+    match egs.catalog_offers(namespace, 0, 10).await {
+        Some(page) => {
+            if let Some(paging) = &page.paging {
+                println!("Total offers in '{}': {}", namespace, paging.total);
+            }
+            for offer in &page.elements {
+                println!(
+                    "  [{}] {} (type: {}, items: {})",
+                    offer.id,
+                    offer.title.as_deref().unwrap_or("(untitled)"),
+                    offer.offer_type.as_deref().unwrap_or("unknown"),
+                    offer.items.len(),
+                );
+            }
+        }
+        None => eprintln!("Failed to fetch catalog offers for '{}'", namespace),
+    }
+
+    println!("\n=== Bulk Catalog Items ===\n");
+
+    let assets = egs.list_assets(None, None).await;
+    let items: Vec<(&str, &str)> = assets
+        .iter()
+        .take(3)
+        .map(|a| (a.namespace.as_str(), a.catalog_item_id.as_str()))
+        .collect();
+
+    if items.is_empty() {
+        println!("No assets found, skipping bulk catalog demo.");
+        return;
+    }
+
+    println!("Looking up {} items across namespaces...", items.len());
+    match egs.bulk_catalog_items(&items).await {
+        Some(result) => {
+            for (ns, items_map) in &result {
+                for (item_id, info) in items_map {
+                    println!(
+                        "  {}/{}: {}",
+                        ns,
+                        item_id,
+                        info.title.as_deref().unwrap_or("(untitled)")
+                    );
+                }
+            }
+        }
+        None => eprintln!("Failed to fetch bulk catalog items"),
+    }
+}

--- a/examples/client_credentials.rs
+++ b/examples/client_credentials.rs
@@ -1,0 +1,36 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Client Credentials Auth ===\n");
+
+    let mut client_egs = EpicGames::new();
+    if client_egs.auth_client_credentials().await {
+        println!("Client credentials auth succeeded");
+        println!(
+            "Token type: client_credentials (limited permissions, no user context)"
+        );
+    } else {
+        eprintln!("Client credentials auth failed");
+        return;
+    }
+
+    println!("\n=== Library State Token Status ===\n");
+
+    let test_token = "test-token-id";
+    match egs.library_state_token_status(test_token).await {
+        Some(valid) => println!("Token '{}' valid: {}", test_token, valid),
+        None => println!("Token '{}': could not check status (API error or invalid)", test_token),
+    }
+}

--- a/examples/commerce.rs
+++ b/examples/commerce.rs
@@ -1,0 +1,97 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Currencies ===\n");
+
+    match egs.currencies(0, 20).await {
+        Some(page) => {
+            if let Some(paging) = &page.paging {
+                println!("Total currencies: {}", paging.total);
+            }
+            for currency in &page.elements {
+                println!(
+                    "  {} ({}) - {} decimals",
+                    currency.code,
+                    currency.symbol.as_deref().unwrap_or("?"),
+                    currency.decimals.unwrap_or(0),
+                );
+            }
+        }
+        None => eprintln!("Failed to fetch currencies"),
+    }
+
+    println!("\n=== Billing Account ===\n");
+
+    match egs.billing_account().await {
+        Some(account) => {
+            println!("Billing ID: {}", account.id.as_deref().unwrap_or("(none)"));
+            println!(
+                "Country: {}",
+                account.country.as_deref().unwrap_or("(none)")
+            );
+        }
+        None => eprintln!("Failed to fetch billing account"),
+    }
+
+    println!("\n=== Offer Prices ===\n");
+
+    let assets = egs.list_assets(None, None).await;
+    if let Some(asset) = assets.first() {
+        let billing_country = egs
+            .billing_account()
+            .await
+            .and_then(|b| b.country)
+            .unwrap_or_else(|| "US".to_string());
+
+        let offer_ids = vec![asset.catalog_item_id.clone()];
+        match egs
+            .offer_prices(&asset.namespace, &offer_ids, &billing_country)
+            .await
+        {
+            Some(response) => {
+                for offer in &response.offers {
+                    println!("  Offer: {}", offer.offer_id);
+                    if let Some(price) = &offer.current_price {
+                        if let Some(fmt) = &price.fmt_price {
+                            println!(
+                                "    Original: {}",
+                                fmt.original_price.as_deref().unwrap_or("N/A")
+                            );
+                            println!(
+                                "    Discount: {}",
+                                fmt.discount_price.as_deref().unwrap_or("N/A")
+                            );
+                        }
+                    }
+                }
+            }
+            None => eprintln!("Failed to fetch offer prices"),
+        }
+    } else {
+        println!("No assets found, skipping offer prices demo.");
+    }
+
+    println!("\n=== Quick Purchase (dry run - commented out) ===\n");
+    println!("Quick purchase is destructive (claims a free game). Example usage:");
+    println!("  egs.quick_purchase(\"namespace\", \"offer_id\").await");
+    println!("Uncomment the code below to try it with a real free offer.");
+    // match egs.quick_purchase("namespace", "offer_id").await {
+    //     Some(response) => {
+    //         println!("  Order ID: {}", response.order_id.unwrap_or_default());
+    //         println!("  Status: {}", response.status.unwrap_or_default());
+    //     }
+    //     None => eprintln!("  Quick purchase failed"),
+    // }
+}

--- a/examples/common.rs
+++ b/examples/common.rs
@@ -1,0 +1,89 @@
+use egs_api::EpicGames;
+use std::io;
+use std::path::PathBuf;
+
+const TOKEN_FILE: &str = ".egs-api/token.json";
+
+fn token_path() -> PathBuf {
+    dirs_or_home().join(TOKEN_FILE)
+}
+
+fn dirs_or_home() -> PathBuf {
+    std::env::var("HOME")
+        .or_else(|_| std::env::var("USERPROFILE"))
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("."))
+}
+
+/// Save the current session token to disk
+pub fn save_token(egs: &EpicGames) {
+    let path = token_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let user_data = egs.user_details();
+    match serde_json::to_string_pretty(&user_data) {
+        Ok(json) => {
+            if std::fs::write(&path, &json).is_ok() {
+                println!("[auth] Token saved to {}", path.display());
+            } else {
+                eprintln!("[auth] Failed to write token to {}", path.display());
+            }
+        }
+        Err(e) => eprintln!("[auth] Failed to serialize token: {}", e),
+    }
+}
+
+/// Try to restore a session from a saved token, refreshing if needed.
+/// If no valid token exists, prompt for an authorization code.
+/// Returns true if logged in successfully.
+pub async fn login_or_restore(egs: &mut EpicGames) -> bool {
+    let path = token_path();
+    if path.exists() {
+        if let Ok(json) = std::fs::read_to_string(&path) {
+            if let Ok(user_data) = serde_json::from_str(&json) {
+                egs.set_user_details(user_data);
+                println!("[auth] Loaded saved token from {}", path.display());
+
+                if egs.login().await {
+                    println!("[auth] Session restored successfully");
+                    save_token(egs);
+                    return true;
+                }
+                println!("[auth] Saved token expired, need fresh login");
+            }
+        }
+    }
+
+    prompt_auth_code(egs).await
+}
+
+/// Open the Epic login page and prompt for the authorization code.
+/// Returns true if login succeeded.
+pub async fn prompt_auth_code(egs: &mut EpicGames) -> bool {
+    let login_url = "https://www.epicgames.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D34a02cf8f4414e29b15921876da36f9a%26responseType%3Dcode";
+
+    if webbrowser::open(login_url).is_err() {
+        println!("Please open this URL in your browser:");
+        println!("{}", login_url);
+    }
+
+    println!("Enter the 'authorizationCode' value from the JSON response:");
+    let mut code = String::new();
+    io::stdin().read_line(&mut code).unwrap();
+    let code = code.trim().replace('"', "");
+
+    if code.is_empty() {
+        eprintln!("[auth] No authorization code provided");
+        return false;
+    }
+
+    if egs.auth_code(None, Some(code)).await {
+        println!("[auth] Logged in successfully");
+        save_token(egs);
+        true
+    } else {
+        eprintln!("[auth] Login failed");
+        false
+    }
+}

--- a/examples/entitlements.rs
+++ b/examples/entitlements.rs
@@ -1,0 +1,27 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== User Entitlements ===\n");
+
+    let entitlements = egs.user_entitlements().await;
+    println!("Total entitlements: {}", entitlements.len());
+
+    for ent in entitlements.iter().take(20) {
+        println!("  {:?}", ent);
+    }
+    if entitlements.len() > 20 {
+        println!("  ... and {} more", entitlements.len() - 20);
+    }
+}

--- a/examples/fab.rs
+++ b/examples/fab.rs
@@ -1,0 +1,111 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    let account_id = egs.user_details().account_id.unwrap_or_default();
+    if account_id.is_empty() {
+        eprintln!("No account ID available");
+        std::process::exit(1);
+    }
+
+    println!("=== Fab Library ===\n");
+
+    match egs.fab_library_items(account_id).await {
+        Some(library) => {
+            println!("Total Fab library items: {}", library.results.len());
+            for item in library.results.iter().take(10) {
+                println!("  {:?}", item);
+            }
+            if library.results.len() > 10 {
+                println!("  ... and {} more", library.results.len() - 10);
+            }
+        }
+        None => {
+            eprintln!("Failed to fetch Fab library");
+            return;
+        }
+    }
+
+    println!("\n=== Fab Asset Manifest (Kite Demo) ===\n");
+
+    let manifest_result = egs
+        .fab_asset_manifest(
+            "KiteDemo473",
+            "89efe5924d3d467c839449ab6ab52e7f",
+            "28166226c38a4ff3aa28bbe87dcbbe5b",
+            None,
+        )
+        .await;
+
+    match manifest_result {
+        Ok(download_infos) => {
+            println!("Got {} download info(s)", download_infos.len());
+
+            for info in &download_infos {
+                println!("  Manifest hash: {}", info.manifest_hash);
+                println!(
+                    "  Distribution points: {:?}",
+                    info.distribution_point_base_urls
+                );
+
+                println!("\n=== Fab Download Manifest ===\n");
+
+                for url in &info.distribution_point_base_urls {
+                    println!("Trying distribution point: {}", url);
+                    match egs.fab_download_manifest(info.clone(), url).await {
+                        Ok(dm) => {
+                            println!("  App: {}", dm.app_name_string);
+                            println!("  Build: {}", dm.build_version_string);
+                            println!("  Files: {}", dm.file_manifest_list.len());
+                            println!("  Chunks: {}", dm.chunk_hash_list.len());
+                            println!(
+                                "  Hash match: {} == {}",
+                                info.manifest_hash,
+                                dm.custom_field("DownloadedManifestHash")
+                                    .unwrap_or_default()
+                            );
+                            break;
+                        }
+                        Err(e) => {
+                            eprintln!("  Failed from {}: {:?}", url, e);
+                        }
+                    }
+                }
+            }
+        }
+        Err(egs_api::api::error::EpicAPIError::FabTimeout) => {
+            eprintln!("Fab API timed out (403). Try running the example again.");
+        }
+        Err(e) => eprintln!("Failed to fetch Fab asset manifest: {:?}", e),
+    }
+
+    println!("\n=== Fab File Download Info ===\n");
+
+    match egs
+        .fab_file_download_info("some-listing-id", "some-format-id", "some-file-id")
+        .await
+    {
+        Some(info) => {
+            println!("  Manifest hash: {}", info.manifest_hash);
+            println!(
+                "  Distribution points: {:?}",
+                info.distribution_point_base_urls
+            );
+        }
+        None => {
+            println!("  fab_file_download_info requires valid Fab listing/format/file IDs.");
+            println!("  Replace the placeholder IDs above with real values from your Fab library.");
+        }
+    }
+}

--- a/examples/game_token.rs
+++ b/examples/game_token.rs
@@ -27,7 +27,7 @@ async fn main() {
 
     let assets = egs.list_assets(None, None).await;
     match assets.first() {
-        Some(asset) => match egs.ownership_token(asset.clone()).await {
+        Some(asset) => match egs.ownership_token(asset).await {
             Some(token) => {
                 println!(
                     "Ownership token for {} (first 80 chars): {}...",

--- a/examples/game_token.rs
+++ b/examples/game_token.rs
@@ -1,0 +1,42 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Game Token ===\n");
+
+    match egs.game_token().await {
+        Some(token) => {
+            println!("Exchange code: {}", token.code);
+            println!("Expires in: {} seconds", token.expires_in_seconds);
+        }
+        None => eprintln!("Failed to fetch game token"),
+    }
+
+    println!("\n=== Ownership Token ===\n");
+
+    let assets = egs.list_assets(None, None).await;
+    match assets.first() {
+        Some(asset) => match egs.ownership_token(asset.clone()).await {
+            Some(token) => {
+                println!(
+                    "Ownership token for {} (first 80 chars): {}...",
+                    asset.app_name,
+                    &token[..token.len().min(80)]
+                );
+            }
+            None => eprintln!("Failed to get ownership token for {}", asset.app_name),
+        },
+        None => println!("No assets found, skipping ownership token demo"),
+    }
+}

--- a/examples/library.rs
+++ b/examples/library.rs
@@ -1,0 +1,30 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Library Items ===\n");
+
+    match egs.library_items(true).await {
+        Some(library) => {
+            println!("Total library records: {}", library.records.len());
+            for record in library.records.iter().take(20) {
+                println!("  {:?}", record);
+            }
+            if library.records.len() > 20 {
+                println!("  ... and {} more", library.records.len() - 20);
+            }
+        }
+        None => eprintln!("Failed to fetch library items"),
+    }
+}

--- a/examples/presence.rs
+++ b/examples/presence.rs
@@ -1,0 +1,43 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::api::types::presence::{PresenceActivity, PresenceUpdate};
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Update Presence ===\n");
+
+    let session_id = egs
+        .user_details()
+        .account_id
+        .unwrap_or_default();
+
+    if session_id.is_empty() {
+        eprintln!("No access token available for presence update");
+        std::process::exit(1);
+    }
+
+    let update = PresenceUpdate {
+        status: Some("online".to_string()),
+        activity: Some(PresenceActivity {
+            r#type: Some("playing".to_string()),
+            properties: Some(serde_json::json!({
+                "FriendableGame": "Fortnite"
+            })),
+        }),
+    };
+
+    match egs.update_presence(&session_id, &update).await {
+        Ok(()) => println!("Presence updated successfully"),
+        Err(e) => eprintln!("Failed to update presence: {:?}", e),
+    }
+}

--- a/examples/status.rs
+++ b/examples/status.rs
@@ -1,0 +1,40 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Service Status (Fortnite) ===\n");
+
+    match egs.service_status("fortnite").await {
+        Some(statuses) => {
+            for status in &statuses {
+                println!("  Service: {}", status.service_instance_id);
+                println!("  Status: {}", status.status);
+                if let Some(msg) = &status.message {
+                    println!("  Message: {}", msg);
+                }
+                if let Some(banned) = status.banned {
+                    println!("  Banned: {}", banned);
+                }
+                if let Some(launcher) = &status.launcher_info_dto {
+                    println!(
+                        "  App: {}",
+                        launcher.app_name.as_deref().unwrap_or("(none)")
+                    );
+                }
+                println!();
+            }
+        }
+        None => eprintln!("Failed to fetch service status"),
+    }
+}

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,12 +1,11 @@
 use crate::api::error::EpicAPIError;
-use crate::api::types::account::{AccountData, AccountInfo};
+use crate::api::types::account::{AccountData, AccountInfo, ExternalAuth};
+use crate::api::types::entitlement::Entitlement;
 use crate::api::types::friends::Friend;
 use crate::api::EpicAPI;
-use log::{error, warn};
-use url::Url;
-use crate::api::types::entitlement::Entitlement;
 
 impl EpicAPI {
+    /// Fetch account details for the logged-in user.
     pub async fn account_details(&mut self) -> Result<AccountData, EpicAPIError> {
         let id = match &self.user_data.account_id {
             Some(id) => id,
@@ -16,36 +15,10 @@ impl EpicAPI {
             "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account/{}",
             id
         );
-        match self
-            .authorized_get_client(Url::parse(&url).unwrap())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(details) => Ok(details),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+        self.authorized_get_json(&url).await
     }
 
+    /// Fetch display names for a list of account IDs.
     pub async fn account_ids_details(
         &mut self,
         ids: Vec<String>,
@@ -53,39 +26,14 @@ impl EpicAPI {
         if ids.is_empty() {
             return Err(EpicAPIError::InvalidParams);
         }
-        let url =
-            "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account"
-                .to_string();
-        let mut parsed_url = Url::parse(&url).unwrap();
-        let mut query = "accountId=".to_string();
-        query.push_str(&ids.join("&accountId="));
-        parsed_url.set_query(Some(&query));
-        match self.authorized_get_client(parsed_url).send().await {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(details) => Ok(details),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+        let url = format!(
+            "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account?accountId={}",
+            ids.join("&accountId=")
+        );
+        self.authorized_get_json(&url).await
     }
 
+    /// Fetch the friends list, optionally including pending requests.
     pub async fn account_friends(
         &mut self,
         include_pending: bool,
@@ -95,37 +43,13 @@ impl EpicAPI {
             None => return Err(EpicAPIError::InvalidParams),
         };
         let url = format!(
-            "https://friends-public-service-prod06.ol.epicgames.com/friends/api/public/friends/{}?includePending={}", id, include_pending);
-        match self
-            .authorized_get_client(Url::parse(&url).unwrap())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(details) => Ok(details),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+            "https://friends-public-service-prod06.ol.epicgames.com/friends/api/public/friends/{}?includePending={}",
+            id, include_pending
+        );
+        self.authorized_get_json(&url).await
     }
 
+    /// Fetch all entitlements for the logged-in user.
     pub async fn user_entitlements(&self) -> Result<Vec<Entitlement>, EpicAPIError> {
         let url = match &self.user_data.account_id {
             None => {
@@ -136,33 +60,26 @@ impl EpicAPI {
                         id)
             }
         };
-        match self
-            .authorized_get_client(Url::parse(&url).unwrap())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(ent) => Ok(ent),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+        self.authorized_get_json(&url).await
+    }
+
+    /// Fetch external auth connections for an account.
+    pub async fn external_auths(
+        &self,
+        account_id: &str,
+    ) -> Result<Vec<ExternalAuth>, EpicAPIError> {
+        let url = format!(
+            "https://account-public-service-prod03.ol.epicgames.com/account/api/public/account/{}/externalAuths",
+            account_id
+        );
+        self.authorized_get_json(&url).await
+    }
+
+    /// Fetch SSO domain list for Epic accounts.
+    pub async fn sso_domains(&self) -> Result<Vec<String>, EpicAPIError> {
+        self.authorized_get_json(
+            "https://account-public-service-prod03.ol.epicgames.com/account/api/epicdomains/ssodomains",
+        )
+        .await
     }
 }

--- a/src/api/binary_rw.rs
+++ b/src/api/binary_rw.rs
@@ -1,0 +1,319 @@
+use std::convert::TryInto;
+
+pub(crate) struct BinaryReader<'a> {
+    buffer: &'a [u8],
+    position: usize,
+}
+
+impl<'a> BinaryReader<'a> {
+    pub fn new(buffer: &'a [u8]) -> Self {
+        Self {
+            buffer,
+            position: 0,
+        }
+    }
+
+    pub fn with_position(buffer: &'a [u8], position: usize) -> Self {
+        Self { buffer, position }
+    }
+
+    pub fn position(&self) -> usize {
+        self.position
+    }
+
+    pub fn set_position(&mut self, pos: usize) {
+        self.position = pos;
+    }
+
+    pub fn remaining(&self) -> usize {
+        self.buffer.len().saturating_sub(self.position)
+    }
+
+    pub fn read_u32(&mut self) -> Option<u32> {
+        if self.remaining() < 4 {
+            return None;
+        }
+        let val = u32::from_le_bytes(
+            self.buffer[self.position..self.position + 4]
+                .try_into()
+                .ok()?,
+        );
+        self.position += 4;
+        Some(val)
+    }
+
+    pub fn read_i32(&mut self) -> Option<i32> {
+        if self.remaining() < 4 {
+            return None;
+        }
+        let val = i32::from_le_bytes(
+            self.buffer[self.position..self.position + 4]
+                .try_into()
+                .ok()?,
+        );
+        self.position += 4;
+        Some(val)
+    }
+
+    pub fn read_u64(&mut self) -> Option<u64> {
+        if self.remaining() < 8 {
+            return None;
+        }
+        let val = u64::from_le_bytes(
+            self.buffer[self.position..self.position + 8]
+                .try_into()
+                .ok()?,
+        );
+        self.position += 8;
+        Some(val)
+    }
+
+    pub fn read_i64(&mut self) -> Option<i64> {
+        if self.remaining() < 8 {
+            return None;
+        }
+        let val = i64::from_le_bytes(
+            self.buffer[self.position..self.position + 8]
+                .try_into()
+                .ok()?,
+        );
+        self.position += 8;
+        Some(val)
+    }
+
+    pub fn read_u8(&mut self) -> Option<u8> {
+        if self.remaining() < 1 {
+            return None;
+        }
+        let val = self.buffer[self.position];
+        self.position += 1;
+        Some(val)
+    }
+
+    pub fn read_bytes(&mut self, n: usize) -> Option<&'a [u8]> {
+        if self.remaining() < n {
+            return None;
+        }
+        let slice = &self.buffer[self.position..self.position + n];
+        self.position += n;
+        Some(slice)
+    }
+
+    pub fn read_fstring(&mut self) -> Option<String> {
+        crate::api::utils::read_fstring(self.buffer, &mut self.position)
+    }
+
+    pub fn read_guid(&mut self) -> Option<String> {
+        let a = self.read_u32()?;
+        let b = self.read_u32()?;
+        let c = self.read_u32()?;
+        let d = self.read_u32()?;
+        Some(format!("{:08x}{:08x}{:08x}{:08x}", a, b, c, d))
+    }
+
+    pub fn skip(&mut self, n: usize) -> Option<()> {
+        if self.remaining() < n {
+            return None;
+        }
+        self.position += n;
+        Some(())
+    }
+}
+
+pub(crate) struct BinaryWriter {
+    data: Vec<u8>,
+}
+
+impl BinaryWriter {
+    pub fn new() -> Self {
+        Self { data: Vec::new() }
+    }
+
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+        }
+    }
+
+    pub fn write_u32(&mut self, val: u32) {
+        self.data.extend_from_slice(&val.to_le_bytes());
+    }
+
+    pub fn write_i32(&mut self, val: i32) {
+        self.data.extend_from_slice(&val.to_le_bytes());
+    }
+
+    pub fn write_u64(&mut self, val: u64) {
+        self.data.extend_from_slice(&val.to_le_bytes());
+    }
+
+    pub fn write_i64(&mut self, val: i64) {
+        self.data.extend_from_slice(&val.to_le_bytes());
+    }
+
+    pub fn write_u8(&mut self, val: u8) {
+        self.data.push(val);
+    }
+
+    pub fn write_bytes(&mut self, bytes: &[u8]) {
+        self.data.extend_from_slice(bytes);
+    }
+
+    pub fn write_fstring(&mut self, s: &str) {
+        let bytes = crate::api::utils::write_fstring(s);
+        self.data.extend_from_slice(&bytes);
+    }
+
+    pub fn write_guid(&mut self, guid: &str) {
+        let subs: Vec<&str> = guid
+            .as_bytes()
+            .chunks(8)
+            .map(|c| std::str::from_utf8(c).unwrap_or("00000000"))
+            .collect();
+        for g in subs {
+            self.write_u32(u32::from_str_radix(g, 16).unwrap_or(0));
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn into_vec(self) -> Vec<u8> {
+        self.data
+    }
+
+    pub fn as_slice(&self) -> &[u8] {
+        &self.data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BinaryReader, BinaryWriter};
+
+    #[test]
+    fn reader_read_u32() {
+        let buffer = [1u8, 2, 3, 4];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.read_u32(), Some(0x04030201));
+        assert_eq!(reader.position(), 4);
+    }
+
+    #[test]
+    fn reader_read_u32_not_enough_bytes() {
+        let buffer = [1u8, 2, 3];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.read_u32(), None);
+        assert_eq!(reader.position(), 0);
+    }
+
+    #[test]
+    fn reader_read_i32() {
+        let buffer = [237u8, 201, 255, 255];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.read_i32(), Some(-13843));
+        assert_eq!(reader.position(), 4);
+    }
+
+    #[test]
+    fn reader_read_u64() {
+        let buffer = [0u8, 0, 5, 3, 0, 1, 2, 3];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.read_u64(), Some(216736831629492224));
+        assert_eq!(reader.position(), 8);
+    }
+
+    #[test]
+    fn reader_read_i64() {
+        let buffer = [237u8, 201, 255, 255, 255, 255, 255, 255];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.read_i64(), Some(-13843));
+        assert_eq!(reader.position(), 8);
+    }
+
+    #[test]
+    fn reader_read_u8() {
+        let buffer = [9u8];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.read_u8(), Some(9));
+        assert_eq!(reader.position(), 1);
+    }
+
+    #[test]
+    fn reader_read_bytes() {
+        let buffer = [1u8, 2, 3, 4, 5];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.read_bytes(3), Some(&buffer[0..3]));
+        assert_eq!(reader.position(), 3);
+    }
+
+    #[test]
+    fn reader_read_guid() {
+        let mut writer = BinaryWriter::new();
+        writer.write_u32(1);
+        writer.write_u32(2);
+        writer.write_u32(3);
+        writer.write_u32(4);
+        let data = writer.into_vec();
+        let mut reader = BinaryReader::new(&data);
+        assert_eq!(
+            reader.read_guid(),
+            Some("00000001000000020000000300000004".to_string())
+        );
+    }
+
+    #[test]
+    fn reader_read_fstring() {
+        let mut writer = BinaryWriter::new();
+        writer.write_fstring("hello");
+        let data = writer.into_vec();
+        let mut reader = BinaryReader::new(&data);
+        assert_eq!(reader.read_fstring(), Some("hello".to_string()));
+    }
+
+    #[test]
+    fn reader_skip() {
+        let buffer = [1u8, 2, 3, 4];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.skip(2), Some(()));
+        assert_eq!(reader.read_u8(), Some(3));
+    }
+
+    #[test]
+    fn reader_remaining() {
+        let buffer = [1u8, 2, 3];
+        let mut reader = BinaryReader::new(&buffer);
+        assert_eq!(reader.remaining(), 3);
+        reader.read_u8();
+        assert_eq!(reader.remaining(), 2);
+    }
+
+    #[test]
+    fn writer_u32_roundtrip() {
+        let mut writer = BinaryWriter::new();
+        writer.write_u32(0x04030201);
+        let data = writer.into_vec();
+        let mut reader = BinaryReader::new(&data);
+        assert_eq!(reader.read_u32(), Some(0x04030201));
+    }
+
+    #[test]
+    fn writer_fstring_roundtrip() {
+        let mut writer = BinaryWriter::new();
+        writer.write_fstring("roundtrip");
+        let data = writer.into_vec();
+        let mut reader = BinaryReader::new(&data);
+        assert_eq!(reader.read_fstring(), Some("roundtrip".to_string()));
+    }
+
+    #[test]
+    fn writer_guid_roundtrip() {
+        let mut writer = BinaryWriter::new();
+        let guid = "00000001000000020000000300000004";
+        writer.write_guid(guid);
+        let data = writer.into_vec();
+        let mut reader = BinaryReader::new(&data);
+        assert_eq!(reader.read_guid(), Some(guid.to_string()));
+    }
+}

--- a/src/api/binary_rw.rs
+++ b/src/api/binary_rw.rs
@@ -290,12 +290,29 @@ mod tests {
     }
 
     #[test]
+    fn reader_set_position() {
+        let buffer = [1u8, 2, 3];
+        let mut reader = BinaryReader::new(&buffer);
+        reader.set_position(2);
+        assert_eq!(reader.read_u8(), Some(3));
+    }
+
+    #[test]
     fn writer_u32_roundtrip() {
         let mut writer = BinaryWriter::new();
         writer.write_u32(0x04030201);
         let data = writer.into_vec();
         let mut reader = BinaryReader::new(&data);
         assert_eq!(reader.read_u32(), Some(0x04030201));
+    }
+
+    #[test]
+    fn writer_i32_roundtrip() {
+        let mut writer = BinaryWriter::new();
+        writer.write_i32(-13843);
+        let data = writer.into_vec();
+        let mut reader = BinaryReader::new(&data);
+        assert_eq!(reader.read_i32(), Some(-13843));
     }
 
     #[test]
@@ -315,5 +332,14 @@ mod tests {
         let data = writer.into_vec();
         let mut reader = BinaryReader::new(&data);
         assert_eq!(reader.read_guid(), Some(guid.to_string()));
+    }
+
+    #[test]
+    fn writer_len_as_slice() {
+        let mut writer = BinaryWriter::with_capacity(4);
+        assert_eq!(writer.len(), 0);
+        writer.write_u8(7);
+        assert_eq!(writer.len(), 1);
+        assert_eq!(writer.as_slice(), &[7u8]);
     }
 }

--- a/src/api/commerce.rs
+++ b/src/api/commerce.rs
@@ -1,0 +1,63 @@
+use crate::api::error::EpicAPIError;
+use crate::api::types::billing_account::BillingAccount;
+use crate::api::types::price::PriceResponse;
+use crate::api::types::quick_purchase::QuickPurchaseResponse;
+use crate::api::EpicAPI;
+
+impl EpicAPI {
+    /// Fetch offer prices from the price engine.
+    pub async fn offer_prices(
+        &self,
+        namespace: &str,
+        offer_ids: &[String],
+        country: &str,
+    ) -> Result<PriceResponse, EpicAPIError> {
+        let url = "https://priceengine-public-service-ecomprod01.ol.epicgames.com/priceengine/api/shared/offers/price";
+        let body = serde_json::json!({
+            "namespace": namespace,
+            "offers": offer_ids,
+            "country": country,
+        });
+        self.authorized_post_json(&url, &body).await
+    }
+
+    /// Execute a quick purchase (typically for free game claims).
+    pub async fn quick_purchase(
+        &self,
+        namespace: &str,
+        offer_id: &str,
+    ) -> Result<QuickPurchaseResponse, EpicAPIError> {
+        let id = match &self.user_data.account_id {
+            Some(id) => id.clone(),
+            None => return Err(EpicAPIError::InvalidCredentials),
+        };
+        let url = format!(
+            "https://orderprocessor-public-service-ecomprod01.ol.epicgames.com/orderprocessor/api/shared/accounts/{}/orders/quickPurchase",
+            id
+        );
+        let body = serde_json::json!({
+            "salesChannel": "Launcher-purchase-client",
+            "entitlementSource": "Launcher-purchase-client",
+            "returnSplitPaymentItems": false,
+            "lineOffers": [{
+                "offerId": offer_id,
+                "quantity": 1,
+                "namespace": namespace,
+            }],
+        });
+        self.authorized_post_json(&url, &body).await
+    }
+
+    /// Fetch the default billing account for the logged-in user.
+    pub async fn billing_account(&self) -> Result<BillingAccount, EpicAPIError> {
+        let id = match &self.user_data.account_id {
+            Some(id) => id.clone(),
+            None => return Err(EpicAPIError::InvalidCredentials),
+        };
+        let url = format!(
+            "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/payment/accounts/{}/billingaccounts/default",
+            id
+        );
+        self.authorized_get_json(&url).await
+    }
+}

--- a/src/api/commerce.rs
+++ b/src/api/commerce.rs
@@ -27,14 +27,13 @@ impl EpicAPI {
         namespace: &str,
         offer_id: &str,
     ) -> Result<QuickPurchaseResponse, EpicAPIError> {
-        let id = match &self.user_data.account_id {
-            Some(id) => id.clone(),
+        let url = match &self.user_data.account_id {
+            Some(id) => format!(
+                "https://orderprocessor-public-service-ecomprod01.ol.epicgames.com/orderprocessor/api/shared/accounts/{}/orders/quickPurchase",
+                id
+            ),
             None => return Err(EpicAPIError::InvalidCredentials),
         };
-        let url = format!(
-            "https://orderprocessor-public-service-ecomprod01.ol.epicgames.com/orderprocessor/api/shared/accounts/{}/orders/quickPurchase",
-            id
-        );
         let body = serde_json::json!({
             "salesChannel": "Launcher-purchase-client",
             "entitlementSource": "Launcher-purchase-client",
@@ -50,14 +49,13 @@ impl EpicAPI {
 
     /// Fetch the default billing account for the logged-in user.
     pub async fn billing_account(&self) -> Result<BillingAccount, EpicAPIError> {
-        let id = match &self.user_data.account_id {
-            Some(id) => id.clone(),
+        let url = match &self.user_data.account_id {
+            Some(id) => format!(
+                "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/payment/accounts/{}/billingaccounts/default",
+                id
+            ),
             None => return Err(EpicAPIError::InvalidCredentials),
         };
-        let url = format!(
-            "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/payment/accounts/{}/billingaccounts/default",
-            id
-        );
         self.authorized_get_json(&url).await
     }
 }

--- a/src/api/egs.rs
+++ b/src/api/egs.rs
@@ -1,17 +1,19 @@
 use crate::api::error::EpicAPIError;
 use crate::api::types::asset_info::{AssetInfo, GameToken, OwnershipToken};
 use crate::api::types::asset_manifest::AssetManifest;
+use crate::api::types::catalog_item::CatalogItemPage;
+use crate::api::types::catalog_offer::CatalogOfferPage;
+use crate::api::types::currency::CurrencyPage;
 use crate::api::types::download_manifest::DownloadManifest;
 use crate::api::types::epic_asset::EpicAsset;
 use crate::api::types::library::Library;
 use crate::api::EpicAPI;
-use log::{debug, error, warn};
+use log::{debug, error};
 use std::borrow::BorrowMut;
 use std::collections::HashMap;
-use std::str::FromStr;
-use url::Url;
 
 impl EpicAPI {
+    /// Fetch all owned assets for the given platform and label.
     pub async fn assets(
         &mut self,
         platform: Option<String>,
@@ -20,36 +22,10 @@ impl EpicAPI {
         let plat = platform.unwrap_or_else(|| "Windows".to_string());
         let lab = label.unwrap_or_else(|| "Live".to_string());
         let url = format!("https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/{}?label={}", plat, lab);
-        match self
-            .authorized_get_client(Url::parse(&url).unwrap())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(assets) => Ok(assets),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+        self.authorized_get_json(&url).await
     }
 
+    /// Fetch the asset manifest with CDN download URLs.
     pub async fn asset_manifest(
         &self,
         platform: Option<String>,
@@ -69,43 +45,16 @@ impl EpicAPI {
         };
         let url = format!("https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/v2/platform/{}/namespace/{}/catalogItem/{}/app/{}/label/{}",
                           platform.clone().unwrap_or_else(|| "Windows".to_string()), namespace.clone().unwrap(), item_id.clone().unwrap(), app.clone().unwrap(), label.clone().unwrap_or_else(|| "Live".to_string()));
-        match self
-            .authorized_get_client(Url::parse(&url).unwrap())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json::<AssetManifest>().await {
-                        Ok(mut manifest) => {
-                            manifest.platform = platform;
-                            manifest.label = label;
-                            manifest.namespace = namespace;
-                            manifest.item_id = item_id;
-                            manifest.app = app;
-                            Ok(manifest)
-                        }
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+        let mut manifest: AssetManifest = self.authorized_get_json(&url).await?;
+        manifest.platform = platform;
+        manifest.label = label;
+        manifest.namespace = namespace;
+        manifest.item_id = item_id;
+        manifest.app = app;
+        Ok(manifest)
     }
 
+    /// Download and parse manifests from all CDN mirrors in the asset manifest.
     pub async fn asset_download_manifests(
         &self,
         asset_manifest: AssetManifest,
@@ -120,77 +69,61 @@ impl EpicAPI {
                     queries.push(format!("{}={}", query.name, query.value));
                 }
                 let url = format!("{}?{}", manifest.uri, queries.join("&"));
-                let client = EpicAPI::build_client().build().unwrap();
-                match client.get(Url::from_str(&url).unwrap()).send().await {
-                    Ok(response) => {
-                        if response.status() == reqwest::StatusCode::OK {
-                            match response.bytes().await {
-                                Ok(data) => match DownloadManifest::parse(data.to_vec()) {
-                                    None => {
-                                        error!("Unable to parse the Download Manifest");
-                                    }
-                                    Some(mut man) => {
-                                        let mut url = manifest.uri.clone();
-                                        url.set_path(&match url.path_segments() {
-                                            None => "".to_string(),
-                                            Some(segments) => {
-                                                let mut vec: Vec<&str> = segments.collect();
-                                                vec.remove(vec.len() - 1);
-                                                vec.join("/")
-                                            }
-                                        });
-                                        url.set_query(None);
-                                        url.set_fragment(None);
-                                        man.set_custom_field(
-                                            "BaseUrl".to_string(),
-                                            base_urls.clone(),
-                                        );
-
-                                        if let Some(id) = asset_manifest.item_id.clone() {
-                                            man.set_custom_field(
-                                                "CatalogItemId".to_string(),
-                                                id.clone(),
-                                            );
-                                        }
-                                        if let Some(label) = asset_manifest.label.clone() {
-                                            man.set_custom_field(
-                                                "BuildLabel".to_string(),
-                                                label.clone(),
-                                            );
-                                        }
-                                        if let Some(ns) = asset_manifest.namespace.clone() {
-                                            man.set_custom_field(
-                                                "CatalogNamespace".to_string(),
-                                                ns.clone(),
-                                            );
-                                        }
-
-                                        if let Some(app) = asset_manifest.app.clone() {
-                                            man.set_custom_field(
-                                                "CatalogAssetName".to_string(),
-                                                app.clone(),
-                                            );
-                                        }
-
-                                        man.set_custom_field(
-                                            "SourceURL".to_string(),
-                                            url.to_string(),
-                                        );
-                                        result.push(man)
-                                    }
-                                },
-                                Err(e) => {
-                                    error!("{:?}", e);
-                                }
-                            }
-                        } else {
-                            warn!(
-                                "{} result: {}",
-                                response.status(),
-                                response.text().await.unwrap()
-                            );
+                match self.get_bytes(&url).await {
+                    Ok(data) => match DownloadManifest::parse(data) {
+                        None => {
+                            error!("Unable to parse the Download Manifest");
                         }
-                    }
+                        Some(mut man) => {
+                            let mut url = manifest.uri.clone();
+                            url.set_path(&match url.path_segments() {
+                                None => "".to_string(),
+                                Some(segments) => {
+                                    let mut vec: Vec<&str> = segments.collect();
+                                    vec.remove(vec.len() - 1);
+                                    vec.join("/")
+                                }
+                            });
+                            url.set_query(None);
+                            url.set_fragment(None);
+                            man.set_custom_field(
+                                "BaseUrl".to_string(),
+                                base_urls.clone(),
+                            );
+
+                            if let Some(id) = asset_manifest.item_id.clone() {
+                                man.set_custom_field(
+                                    "CatalogItemId".to_string(),
+                                    id.clone(),
+                                );
+                            }
+                            if let Some(label) = asset_manifest.label.clone() {
+                                man.set_custom_field(
+                                    "BuildLabel".to_string(),
+                                    label.clone(),
+                                );
+                            }
+                            if let Some(ns) = asset_manifest.namespace.clone() {
+                                man.set_custom_field(
+                                    "CatalogNamespace".to_string(),
+                                    ns.clone(),
+                                );
+                            }
+
+                            if let Some(app) = asset_manifest.app.clone() {
+                                man.set_custom_field(
+                                    "CatalogAssetName".to_string(),
+                                    app.clone(),
+                                );
+                            }
+
+                            man.set_custom_field(
+                                "SourceURL".to_string(),
+                                url.to_string(),
+                            );
+                            result.push(man)
+                        }
+                    },
                     Err(e) => {
                         error!("{:?}", e);
                     }
@@ -200,76 +133,25 @@ impl EpicAPI {
         result
     }
 
+    /// Fetch catalog metadata for an asset, including DLC details.
     pub async fn asset_info(
         &self,
         asset: EpicAsset,
     ) -> Result<HashMap<String, AssetInfo>, EpicAPIError> {
         let url = format!("https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/namespace/{}/bulk/items?id={}&includeDLCDetails=true&includeMainGameDetails=true&country=us&locale=lc",
                           asset.namespace, asset.catalog_item_id);
-        match self
-            .authorized_get_client(Url::parse(&url).unwrap())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(info) => Ok(info),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+        self.authorized_get_json(&url).await
     }
 
+    /// Fetch a short-lived game exchange token.
     pub async fn game_token(&self) -> Result<GameToken, EpicAPIError> {
-        let url =
-            "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/exchange"
-                .to_string();
-        match self
-            .authorized_get_client(Url::parse(&url).unwrap())
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(token) => Ok(token),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+        self.authorized_get_json(
+            "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/exchange",
+        )
+        .await
     }
 
+    /// Fetch a JWT ownership token for the given asset.
     pub async fn ownership_token(&self, asset: EpicAsset) -> Result<OwnershipToken, EpicAPIError> {
         let url = match &self.user_data.account_id {
             None => {
@@ -280,40 +162,17 @@ impl EpicAPI {
                         id)
             }
         };
-        match self
-            .authorized_post_client(Url::parse(&url).unwrap())
-            .form(&[(
+        self.authorized_post_form_json(
+            &url,
+            &[(
                 "nsCatalogItemId".to_string(),
                 format!("{}:{}", asset.namespace, asset.catalog_item_id),
-            )])
-            .send()
-            .await
-        {
-            Ok(response) => {
-                if response.status() == reqwest::StatusCode::OK {
-                    match response.json().await {
-                        Ok(token) => Ok(token),
-                        Err(e) => {
-                            error!("{:?}", e);
-                            Err(EpicAPIError::Unknown)
-                        }
-                    }
-                } else {
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap()
-                    );
-                    Err(EpicAPIError::Unknown)
-                }
-            }
-            Err(e) => {
-                error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
-            }
-        }
+            )],
+        )
+        .await
     }
 
+    /// Fetch all library items, paginating internally.
     pub async fn library_items(&mut self, include_metadata: bool) -> Result<Library, EpicAPIError> {
         let mut library = Library {
             records: vec![],
@@ -330,50 +189,107 @@ impl EpicAPI {
                 }
             };
 
-            match self
-                .authorized_get_client(Url::parse(&url).unwrap())
-                .send()
-                .await
-            {
-                Ok(response) => {
-                    if response.status() == reqwest::StatusCode::OK {
-                        match response.json::<Library>().await {
-                            Ok(mut records) => {
-                                library.records.append(records.records.borrow_mut());
-                                match records.response_metadata {
-                                    None => {
-                                        break;
-                                    }
-                                    Some(meta) => match meta.next_cursor {
-                                        None => {
-                                            break;
-                                        }
-                                        Some(curs) => {
-                                            cursor = Some(curs);
-                                        }
-                                    },
-                                }
-                            }
-                            Err(e) => {
-                                error!("{:?}", e);
-                            }
+            match self.authorized_get_json::<Library>(&url).await {
+                Ok(mut records) => {
+                    library.records.append(records.records.borrow_mut());
+                    match records.response_metadata {
+                        None => {
+                            break;
                         }
-                    } else {
-                        warn!(
-                            "{} result: {}",
-                            response.status(),
-                            response.text().await.unwrap()
-                        );
+                        Some(meta) => match meta.next_cursor {
+                            None => {
+                                break;
+                            }
+                            Some(curs) => {
+                                cursor = Some(curs);
+                            }
+                        },
                     }
                 }
                 Err(e) => {
                     error!("{:?}", e);
+                    break;
                 }
             };
-            if cursor.is_none() {
-                break;
-            }
         }
         Ok(library)
+    }
+
+    /// Fetch paginated catalog items for a namespace.
+    pub async fn catalog_items(
+        &self,
+        namespace: &str,
+        start: i64,
+        count: i64,
+    ) -> Result<CatalogItemPage, EpicAPIError> {
+        let url = format!(
+            "https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/namespace/{}/items?start={}&count={}",
+            namespace, start, count
+        );
+        self.authorized_get_json(&url).await
+    }
+
+    /// Fetch paginated catalog offers for a namespace.
+    pub async fn catalog_offers(
+        &self,
+        namespace: &str,
+        start: i64,
+        count: i64,
+    ) -> Result<CatalogOfferPage, EpicAPIError> {
+        let url = format!(
+            "https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/namespace/{}/offers?start={}&count={}",
+            namespace, start, count
+        );
+        self.authorized_get_json(&url).await
+    }
+
+    /// Bulk fetch catalog items across multiple namespaces.
+    pub async fn bulk_catalog_items(
+        &self,
+        items: &[(&str, &str)],
+    ) -> Result<HashMap<String, HashMap<String, AssetInfo>>, EpicAPIError> {
+        let body: Vec<serde_json::Value> = items
+            .iter()
+            .map(|(ns, id)| {
+                serde_json::json!({
+                    "id": id,
+                    "namespace": ns,
+                    "includeDLCDetails": true,
+                    "includeMainGameDetails": true,
+                    "country": "us",
+                    "locale": "lc",
+                })
+            })
+            .collect();
+        self.authorized_post_json(
+            "https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/bulk/namespaces/items",
+            &body,
+        )
+        .await
+    }
+
+    /// Fetch available currencies.
+    pub async fn currencies(
+        &self,
+        start: i64,
+        count: i64,
+    ) -> Result<CurrencyPage, EpicAPIError> {
+        let url = format!(
+            "https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/currencies?start={}&count={}",
+            start, count
+        );
+        self.authorized_get_json(&url).await
+    }
+
+    /// Check the status of a library state token.
+    pub async fn library_state_token_status(
+        &self,
+        token_id: &str,
+    ) -> Result<bool, EpicAPIError> {
+        let url = format!(
+            "https://library-service.live.use1a.on.epicgames.com/library/api/public/stateToken/{}/status",
+            token_id
+        );
+        self.authorized_get_json(&url).await
     }
 }

--- a/src/api/egs.rs
+++ b/src/api/egs.rs
@@ -44,7 +44,7 @@ impl EpicAPI {
             return Err(EpicAPIError::InvalidParams);
         };
         let url = format!("https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/v2/platform/{}/namespace/{}/catalogItem/{}/app/{}/label/{}",
-                          platform.clone().unwrap_or_else(|| "Windows".to_string()), namespace.clone().unwrap(), item_id.clone().unwrap(), app.clone().unwrap(), label.clone().unwrap_or_else(|| "Live".to_string()));
+                          platform.as_deref().unwrap_or("Windows"), namespace.as_deref().unwrap(), item_id.as_deref().unwrap(), app.as_deref().unwrap(), label.as_deref().unwrap_or("Live"));
         let mut manifest: AssetManifest = self.authorized_get_json(&url).await?;
         manifest.platform = platform;
         manifest.label = label;
@@ -86,41 +86,24 @@ impl EpicAPI {
                             });
                             url.set_query(None);
                             url.set_fragment(None);
-                            man.set_custom_field(
-                                "BaseUrl".to_string(),
-                                base_urls.clone(),
-                            );
+                            man.set_custom_field("BaseUrl", &base_urls);
 
-                            if let Some(id) = asset_manifest.item_id.clone() {
-                                man.set_custom_field(
-                                    "CatalogItemId".to_string(),
-                                    id.clone(),
-                                );
+                            if let Some(id) = asset_manifest.item_id.as_deref() {
+                                man.set_custom_field("CatalogItemId", id);
                             }
-                            if let Some(label) = asset_manifest.label.clone() {
-                                man.set_custom_field(
-                                    "BuildLabel".to_string(),
-                                    label.clone(),
-                                );
+                            if let Some(label) = asset_manifest.label.as_deref() {
+                                man.set_custom_field("BuildLabel", label);
                             }
-                            if let Some(ns) = asset_manifest.namespace.clone() {
-                                man.set_custom_field(
-                                    "CatalogNamespace".to_string(),
-                                    ns.clone(),
-                                );
+                            if let Some(ns) = asset_manifest.namespace.as_deref() {
+                                man.set_custom_field("CatalogNamespace", ns);
                             }
 
-                            if let Some(app) = asset_manifest.app.clone() {
-                                man.set_custom_field(
-                                    "CatalogAssetName".to_string(),
-                                    app.clone(),
-                                );
+                            if let Some(app) = asset_manifest.app.as_deref() {
+                                man.set_custom_field("CatalogAssetName", app);
                             }
 
-                            man.set_custom_field(
-                                "SourceURL".to_string(),
-                                url.to_string(),
-                            );
+                            let source_url = url.to_string();
+                            man.set_custom_field("SourceURL", &source_url);
                             result.push(man)
                         }
                     },
@@ -136,7 +119,7 @@ impl EpicAPI {
     /// Fetch catalog metadata for an asset, including DLC details.
     pub async fn asset_info(
         &self,
-        asset: EpicAsset,
+        asset: &EpicAsset,
     ) -> Result<HashMap<String, AssetInfo>, EpicAPIError> {
         let url = format!("https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/namespace/{}/bulk/items?id={}&includeDLCDetails=true&includeMainGameDetails=true&country=us&locale=lc",
                           asset.namespace, asset.catalog_item_id);
@@ -152,7 +135,7 @@ impl EpicAPI {
     }
 
     /// Fetch a JWT ownership token for the given asset.
-    pub async fn ownership_token(&self, asset: EpicAsset) -> Result<OwnershipToken, EpicAPIError> {
+    pub async fn ownership_token(&self, asset: &EpicAsset) -> Result<OwnershipToken, EpicAPIError> {
         let url = match &self.user_data.account_id {
             None => {
                 return Err(EpicAPIError::InvalidCredentials);

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -8,8 +8,17 @@ pub enum EpicAPIError {
     InvalidCredentials,
     /// API error - see the contents
     APIError(String),
-    /// Unknown error
-    Unknown,
+    /// Network/transport error from reqwest
+    NetworkError(reqwest::Error),
+    /// Failed to deserialize response body
+    DeserializationError(String),
+    /// HTTP error with non-success status code
+    HttpError {
+        /// HTTP status code
+        status: reqwest::StatusCode,
+        /// Response body text
+        body: String,
+    },
     /// Invalid parameters
     InvalidParams,
     /// Server error
@@ -24,14 +33,20 @@ impl fmt::Display for EpicAPIError {
             EpicAPIError::InvalidCredentials => {
                 write!(f, "Invalid Credentials")
             }
-            EpicAPIError::Unknown => {
-                write!(f, "Unknown Error")
-            }
             EpicAPIError::Server => {
                 write!(f, "Server Error")
             }
             EpicAPIError::APIError(e) => {
                 write!(f, "API Error: {}", e)
+            }
+            EpicAPIError::NetworkError(e) => {
+                write!(f, "Network Error: {}", e)
+            }
+            EpicAPIError::DeserializationError(e) => {
+                write!(f, "Deserialization Error: {}", e)
+            }
+            EpicAPIError::HttpError { status, body } => {
+                write!(f, "HTTP Error {}: {}", status, body)
             }
             EpicAPIError::InvalidParams => {
                 write!(f, "Invalid Input Parameters")
@@ -47,12 +62,20 @@ impl Error for EpicAPIError {
     fn description(&self) -> &str {
         match *self {
             EpicAPIError::InvalidCredentials => "Invalid Credentials",
-            EpicAPIError::Unknown => "Unknown Error",
             EpicAPIError::Server => "Server Error",
             EpicAPIError::APIError(_) => "API Error",
+            EpicAPIError::NetworkError(_) => "Network Error",
+            EpicAPIError::DeserializationError(_) => "Deserialization Error",
+            EpicAPIError::HttpError { .. } => "HTTP Error",
             EpicAPIError::InvalidParams => "Invalid Input Parameters",
             EpicAPIError::FabTimeout => "Fab Timeout Error",
         }
+    }
+}
+
+impl From<reqwest::Error> for EpicAPIError {
+    fn from(e: reqwest::Error) -> Self {
+        EpicAPIError::NetworkError(e)
     }
 }
 
@@ -78,8 +101,35 @@ mod tests {
     }
 
     #[test]
-    fn display_unknown() {
-        assert_eq!(format!("{}", EpicAPIError::Unknown), "Unknown Error");
+    fn display_network_error() {
+        let err = reqwest::blocking::Client::new()
+            .get("http://")
+            .send()
+            .unwrap_err();
+        let message = format!("{}", EpicAPIError::NetworkError(err));
+        assert!(message.starts_with("Network Error: "));
+    }
+
+    #[test]
+    fn display_deserialization_error() {
+        assert_eq!(
+            format!("{}", EpicAPIError::DeserializationError("test".into())),
+            "Deserialization Error: test"
+        );
+    }
+
+    #[test]
+    fn display_http_error() {
+        assert_eq!(
+            format!(
+                "{}",
+                EpicAPIError::HttpError {
+                    status: reqwest::StatusCode::BAD_REQUEST,
+                    body: "bad".to_string()
+                }
+            ),
+            "HTTP Error 400 Bad Request: bad"
+        );
     }
 
     #[test]
@@ -107,11 +157,30 @@ mod tests {
             EpicAPIError::InvalidCredentials.description(),
             "Invalid Credentials"
         );
-        assert_eq!(EpicAPIError::Unknown.description(), "Unknown Error");
         assert_eq!(EpicAPIError::Server.description(), "Server Error");
         assert_eq!(
             EpicAPIError::APIError("x".into()).description(),
             "API Error"
+        );
+        let err = reqwest::blocking::Client::new()
+            .get("http://")
+            .send()
+            .unwrap_err();
+        assert_eq!(
+            EpicAPIError::NetworkError(err).description(),
+            "Network Error"
+        );
+        assert_eq!(
+            EpicAPIError::DeserializationError("x".into()).description(),
+            "Deserialization Error"
+        );
+        assert_eq!(
+            EpicAPIError::HttpError {
+                status: reqwest::StatusCode::INTERNAL_SERVER_ERROR,
+                body: "fail".into()
+            }
+            .description(),
+            "HTTP Error"
         );
         assert_eq!(
             EpicAPIError::InvalidParams.description(),
@@ -122,7 +191,11 @@ mod tests {
 
     #[test]
     fn error_is_debug() {
-        let _ = format!("{:?}", EpicAPIError::Unknown);
+        let err = reqwest::blocking::Client::new()
+            .get("http://")
+            .send()
+            .unwrap_err();
+        let _ = format!("{:?}", EpicAPIError::NetworkError(err));
         let _ = format!("{:?}", EpicAPIError::APIError("msg".into()));
     }
 }

--- a/src/api/error.rs
+++ b/src/api/error.rs
@@ -55,3 +55,74 @@ impl Error for EpicAPIError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::error::Error;
+
+    #[test]
+    fn display_invalid_credentials() {
+        assert_eq!(
+            format!("{}", EpicAPIError::InvalidCredentials),
+            "Invalid Credentials"
+        );
+    }
+
+    #[test]
+    fn display_api_error() {
+        assert_eq!(
+            format!("{}", EpicAPIError::APIError("test".into())),
+            "API Error: test"
+        );
+    }
+
+    #[test]
+    fn display_unknown() {
+        assert_eq!(format!("{}", EpicAPIError::Unknown), "Unknown Error");
+    }
+
+    #[test]
+    fn display_server() {
+        assert_eq!(format!("{}", EpicAPIError::Server), "Server Error");
+    }
+
+    #[test]
+    fn display_invalid_params() {
+        assert_eq!(
+            format!("{}", EpicAPIError::InvalidParams),
+            "Invalid Input Parameters"
+        );
+    }
+
+    #[test]
+    fn display_fab_timeout() {
+        assert_eq!(format!("{}", EpicAPIError::FabTimeout), "Fab Timeout Error");
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn error_description() {
+        assert_eq!(
+            EpicAPIError::InvalidCredentials.description(),
+            "Invalid Credentials"
+        );
+        assert_eq!(EpicAPIError::Unknown.description(), "Unknown Error");
+        assert_eq!(EpicAPIError::Server.description(), "Server Error");
+        assert_eq!(
+            EpicAPIError::APIError("x".into()).description(),
+            "API Error"
+        );
+        assert_eq!(
+            EpicAPIError::InvalidParams.description(),
+            "Invalid Input Parameters"
+        );
+        assert_eq!(EpicAPIError::FabTimeout.description(), "Fab Timeout Error");
+    }
+
+    #[test]
+    fn error_is_debug() {
+        let _ = format!("{:?}", EpicAPIError::Unknown);
+        let _ = format!("{:?}", EpicAPIError::APIError("msg".into()));
+    }
+}

--- a/src/api/fab.rs
+++ b/src/api/fab.rs
@@ -5,10 +5,10 @@ use crate::api::types::fab_library::FabLibrary;
 use crate::api::EpicAPI;
 use log::{debug, error, warn};
 use std::borrow::BorrowMut;
-use std::str::FromStr;
 use url::Url;
 
 impl EpicAPI {
+    /// Fetch Fab asset manifest with signed distribution points. Returns `FabTimeout` on 403.
     pub async fn fab_asset_manifest(
         &self,
         artifact_id: &str,
@@ -17,8 +17,9 @@ impl EpicAPI {
         platform: Option<&str>,
     ) -> Result<Vec<DownloadInfo>, EpicAPIError> {
         let url = format!("https://www.fab.com/e/artifacts/{}/manifest", artifact_id);
+        let parsed_url = Url::parse(&url).map_err(|_| EpicAPIError::InvalidParams)?;
         match self
-            .authorized_post_client(Url::parse(&url).unwrap())
+            .authorized_post_client(parsed_url)
             .json(&serde_json::json!({
                 "item_id": asset_id,
                 "namespace": namespace,
@@ -29,7 +30,7 @@ impl EpicAPI {
         {
             Ok(response) => {
                 if response.status() == reqwest::StatusCode::OK {
-                    let text = response.text().await.unwrap();
+                    let text = response.text().await.unwrap_or_default();
                     match serde_json::from_str::<
                         crate::api::types::fab_asset_manifest::FabAssetManifest,
                     >(&text)
@@ -48,7 +49,7 @@ impl EpicAPI {
                     warn!(
                         "{} result: {}",
                         response.status(),
-                        response.text().await.unwrap()
+                        response.text().await.unwrap_or_default()
                     );
                     Err(EpicAPIError::Unknown)
                 }
@@ -60,6 +61,7 @@ impl EpicAPI {
         }
     }
 
+    /// Download and parse a Fab manifest from a distribution point.
     pub async fn fab_download_manifest(
         &self,
         download_info: DownloadInfo,
@@ -75,40 +77,20 @@ impl EpicAPI {
                     error!("Expired signature");
                     Err(EpicAPIError::Unknown)
                 } else {
-                    let client = EpicAPI::build_client().build().unwrap();
-                    match client
-                        .get(Url::from_str(&point.manifest_url).unwrap())
-                        .send()
-                        .await
-                    {
-                        Ok(response) => {
-                            if response.status() == reqwest::StatusCode::OK {
-                                match response.bytes().await {
-                                    Ok(data) => match DownloadManifest::parse(data.to_vec()) {
-                                        None => {
-                                            error!("Unable to parse the Download Manifest");
-                                            Err(EpicAPIError::Unknown)
-                                        }
-                                        Some(man) => Ok(man),
-                                    },
-                                    Err(_) => Err(EpicAPIError::Unknown),
-                                }
-                            } else {
-                                warn!(
-                                    "{} result: {}",
-                                    response.status(),
-                                    response.text().await.unwrap()
-                                );
-                                Err(EpicAPIError::Unknown)
-                            }
+                    let data = self.get_bytes(&point.manifest_url).await?;
+                    match DownloadManifest::parse(data) {
+                        None => {
+                            error!("Unable to parse the Download Manifest");
+                            Err(EpicAPIError::Unknown)
                         }
-                        Err(_) => Err(EpicAPIError::Unknown),
+                        Some(man) => Ok(man),
                     }
                 }
             }
         }
     }
 
+    /// Fetch all Fab library items, paginating internally.
     pub async fn fab_library_items(
         &mut self,
         account_id: String,
@@ -131,33 +113,10 @@ impl EpicAPI {
                 }
             };
 
-            match self
-                .authorized_get_client(Url::parse(&url).unwrap())
-                .send()
-                .await
-            {
-                Ok(response) => {
-                    if response.status() == reqwest::StatusCode::OK {
-                        let text = response.text().await.unwrap();
-                        match serde_json::from_str::<FabLibrary>(&text) {
-                            Ok(mut api_library) => {
-                                library.cursors.next = api_library.cursors.next;
-                                library.results.append(api_library.results.borrow_mut());
-                            }
-                            Err(e) => {
-                                error!("{:?}", e);
-                                debug!("{}", text);
-                                library.cursors.next = None;
-                            }
-                        }
-                    } else {
-                        debug!("{:?}", response.headers());
-                        warn!(
-                            "{} result: {}",
-                            response.status(),
-                            response.text().await.unwrap()
-                        );
-                    }
+            match self.authorized_get_json::<FabLibrary>(&url).await {
+                Ok(mut api_library) => {
+                    library.cursors.next = api_library.cursors.next;
+                    library.results.append(api_library.results.borrow_mut());
                 }
                 Err(e) => {
                     error!("{:?}", e);
@@ -170,5 +129,19 @@ impl EpicAPI {
         }
 
         Ok(library)
+    }
+
+    /// Fetch download info for a specific file within a Fab listing.
+    pub async fn fab_file_download_info(
+        &self,
+        listing_id: &str,
+        format_id: &str,
+        file_id: &str,
+    ) -> Result<DownloadInfo, EpicAPIError> {
+        let url = format!(
+            "https://www.fab.com/p/egl/listings/{}/asset-formats/{}/files/{}/download-info",
+            listing_id, format_id, file_id
+        );
+        self.authorized_get_json(&url).await
     }
 }

--- a/src/api/fab.rs
+++ b/src/api/fab.rs
@@ -39,24 +39,22 @@ impl EpicAPI {
                         Err(e) => {
                             error!("{:?}", e);
                             debug!("{}", text);
-                            Err(EpicAPIError::Unknown)
+                            Err(EpicAPIError::DeserializationError(format!("{}", e)))
                         }
                     }
                 } else if response.status() == reqwest::StatusCode::FORBIDDEN {
                     Err(EpicAPIError::FabTimeout)
                 } else {
                     debug!("{:?}", response.headers());
-                    warn!(
-                        "{} result: {}",
-                        response.status(),
-                        response.text().await.unwrap_or_default()
-                    );
-                    Err(EpicAPIError::Unknown)
+                    let status = response.status();
+                    let body = response.text().await.unwrap_or_default();
+                    warn!("{} result: {}", status, body);
+                    Err(EpicAPIError::HttpError { status, body })
                 }
             }
             Err(e) => {
                 error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
+                Err(EpicAPIError::NetworkError(e))
             }
         }
     }
@@ -70,18 +68,20 @@ impl EpicAPI {
         match download_info.get_distribution_point_by_base_url(distribution_point_url) {
             None => {
                 error!("Distribution point not found");
-                Err(EpicAPIError::Unknown)
+                Err(EpicAPIError::InvalidParams)
             }
             Some(point) => {
                 if point.signature_expiration < time::OffsetDateTime::now_utc() {
                     error!("Expired signature");
-                    Err(EpicAPIError::Unknown)
+                    Err(EpicAPIError::InvalidParams)
                 } else {
                     let data = self.get_bytes(&point.manifest_url).await?;
                     match DownloadManifest::parse(data) {
                         None => {
                             error!("Unable to parse the Download Manifest");
-                            Err(EpicAPIError::Unknown)
+                            Err(EpicAPIError::DeserializationError(
+                                "Unable to parse the Download Manifest".to_string(),
+                            ))
                         }
                         Some(man) => Ok(man),
                     }

--- a/src/api/login.rs
+++ b/src/api/login.rs
@@ -52,7 +52,7 @@ impl EpicAPI {
             Ok(response) => self.handle_login_response(response).await,
             Err(e) => {
                 error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
+                Err(EpicAPIError::NetworkError(e))
             }
         }
     }
@@ -67,7 +67,7 @@ impl EpicAPI {
             Ok(data) => data,
             Err(e) => {
                 error!("{:?}", e);
-                return Err(EpicAPIError::Unknown);
+                return Err(EpicAPIError::DeserializationError(format!("{}", e)));
             }
         };
 
@@ -91,7 +91,7 @@ impl EpicAPI {
             }
             Err(e) => {
                 error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
+                Err(EpicAPIError::NetworkError(e))
             }
         }
     }
@@ -117,7 +117,7 @@ impl EpicAPI {
             Ok(response) => self.handle_login_response(response).await,
             Err(e) => {
                 error!("{:?}", e);
-                Err(EpicAPIError::Unknown)
+                Err(EpicAPIError::NetworkError(e))
             }
         }
     }

--- a/src/api/login.rs
+++ b/src/api/login.rs
@@ -1,12 +1,11 @@
-use std::str::FromStr;
 use log::{error, info, warn};
 use reqwest::Response;
-use url::Url;
 use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::account::UserData;
 
 impl EpicAPI {
+    /// Start a new OAuth session with exchange token, authorization code, or refresh token.
     pub async fn start_session(
         &mut self,
         exchange_token: Option<String>,
@@ -54,6 +53,7 @@ impl EpicAPI {
         }
     }
 
+    /// Handle the OAuth login response and update user data.
     async fn handle_login_response(&mut self, response: Response) -> Result<bool, EpicAPIError> {
         if response.status() == reqwest::StatusCode::INTERNAL_SERVER_ERROR {
             error!("Server Error");
@@ -76,8 +76,12 @@ impl EpicAPI {
         Ok(true)
     }
 
+    /// Resume an existing session by verifying the access token.
     pub async fn resume_session(&mut self) -> Result<bool, EpicAPIError> {
-        match self.authorized_get_client(Url::parse("https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/verify").unwrap()).send().await {
+        let url = "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/verify";
+        match self.authorized_get_client(
+            url::Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?
+        ).send().await {
             Ok(response) => {
                 self.handle_login_response(response).await
             }
@@ -88,11 +92,37 @@ impl EpicAPI {
         }
     }
 
+    /// Start a client credentials session (app-level auth, no user context).
+    pub async fn start_client_credentials_session(&mut self) -> Result<bool, EpicAPIError> {
+        let params = [
+            ("grant_type".to_string(), "client_credentials".to_string()),
+            ("token_type".to_string(), "eg1".to_string()),
+        ];
+
+        match self
+            .client
+            .post("https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/token")
+            .form(&params)
+            .basic_auth(
+                "34a02cf8f4414e29b15921876da36f9a",
+                Some("daafbccc737745039dffe53d94fc76cf"),
+            )
+            .send()
+            .await
+        {
+            Ok(response) => self.handle_login_response(response).await,
+            Err(e) => {
+                error!("{:?}", e);
+                Err(EpicAPIError::Unknown)
+            }
+        }
+    }
+
+    /// Invalidate the current session (note: method name has a known typo).
     pub async fn invalidate_sesion(&mut self) -> bool {
         if let Some(access_token) = &self.user_data.access_token {
             let url = format!("https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/sessions/kill/{}", access_token);
-            let client = EpicAPI::build_client().build().unwrap();
-            match client.delete(Url::from_str(&url).unwrap()).send().await {
+            match self.client.delete(&url).send().await {
                 Ok(_) => {
                     info!("Session invalidated");
                     return true;

--- a/src/api/login.rs
+++ b/src/api/login.rs
@@ -17,7 +17,11 @@ impl EpicAPI {
                     ("grant_type".to_string(), "refresh_token".to_string()),
                     (
                         "refresh_token".to_string(),
-                        self.user_data.refresh_token.clone().unwrap(),
+                        self.user_data
+                            .refresh_token
+                            .as_ref()
+                            .ok_or(EpicAPIError::InvalidCredentials)?
+                            .clone(),
                     ),
                     ("token_type".to_string(), "eg1".to_string()),
                 ],

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,7 +1,11 @@
+use log::{error, warn};
 use reqwest::header::HeaderMap;
-use reqwest::{Client, ClientBuilder, RequestBuilder};
+use reqwest::{Client, RequestBuilder};
+use serde::de::DeserializeOwned;
 use types::account::UserData;
 use url::Url;
+
+use crate::api::error::EpicAPIError;
 
 /// Module holding the API types
 pub mod types;
@@ -23,22 +27,29 @@ pub mod egs;
 /// Session Handling
 pub mod login;
 
-#[derive(Default, Debug, Clone)]
+/// Commerce Methods (pricing, purchases, billing)
+pub mod commerce;
+
+/// Service Status Methods
+pub mod status;
+
+/// Presence Methods
+pub mod presence;
+
+#[derive(Debug, Clone)]
 pub(crate) struct EpicAPI {
     client: Client,
     pub(crate) user_data: UserData,
 }
 
+impl Default for EpicAPI {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EpicAPI {
     pub fn new() -> Self {
-        let client = EpicAPI::build_client().build().unwrap();
-        EpicAPI {
-            client,
-            user_data: Default::default(),
-        }
-    }
-
-    fn build_client() -> ClientBuilder {
         let mut headers = HeaderMap::new();
         headers.insert(
             "User-Agent",
@@ -50,19 +61,23 @@ impl EpicAPI {
             "X-Epic-Correlation-ID",
             "UE4-c176f7154c2cda1061cc43ab52598e2b-93AFB486488A22FDF70486BD1D883628-BFCD88F649E997BA203FF69F07CE578C".parse().unwrap()
         );
-        reqwest::Client::builder()
+        let client = reqwest::Client::builder()
             .default_headers(headers)
             .cookie_store(true)
+            .build()
+            .unwrap();
+        EpicAPI {
+            client,
+            user_data: Default::default(),
+        }
     }
 
     fn authorized_get_client(&self, url: Url) -> RequestBuilder {
-        let client = EpicAPI::build_client().build().unwrap();
-        self.set_authorization_header(client.get(url))
+        self.set_authorization_header(self.client.get(url))
     }
 
     fn authorized_post_client(&self, url: Url) -> RequestBuilder {
-        let client = EpicAPI::build_client().build().unwrap();
-        self.set_authorization_header(client.post(url))
+        self.set_authorization_header(self.client.post(url))
     }
 
     fn set_authorization_header(&self, rb: RequestBuilder) -> RequestBuilder {
@@ -82,5 +97,121 @@ impl EpicAPI {
         )
     }
 
-    
+    /// Send an authorized GET request and deserialize the JSON response
+    pub(crate) async fn authorized_get_json<T: DeserializeOwned>(
+        &self,
+        url: &str,
+    ) -> Result<T, EpicAPIError> {
+        let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .authorized_get_client(parsed_url)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })?;
+        if response.status() == reqwest::StatusCode::OK {
+            response.json::<T>().await.map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })
+        } else {
+            warn!(
+                "{} result: {}",
+                response.status(),
+                response.text().await.unwrap_or_default()
+            );
+            Err(EpicAPIError::Unknown)
+        }
+    }
+
+    /// Send an authorized POST request with form data and deserialize the JSON response
+    pub(crate) async fn authorized_post_form_json<T: DeserializeOwned>(
+        &self,
+        url: &str,
+        form: &[(String, String)],
+    ) -> Result<T, EpicAPIError> {
+        let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .authorized_post_client(parsed_url)
+            .form(form)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })?;
+        if response.status() == reqwest::StatusCode::OK {
+            response.json::<T>().await.map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })
+        } else {
+            warn!(
+                "{} result: {}",
+                response.status(),
+                response.text().await.unwrap_or_default()
+            );
+            Err(EpicAPIError::Unknown)
+        }
+    }
+
+    /// Send an authorized POST request with a JSON body and deserialize the JSON response
+    pub(crate) async fn authorized_post_json<T: DeserializeOwned, B: serde::Serialize>(
+        &self,
+        url: &str,
+        body: &B,
+    ) -> Result<T, EpicAPIError> {
+        let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .authorized_post_client(parsed_url)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })?;
+        if response.status() == reqwest::StatusCode::OK {
+            response.json::<T>().await.map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })
+        } else {
+            warn!(
+                "{} result: {}",
+                response.status(),
+                response.text().await.unwrap_or_default()
+            );
+            Err(EpicAPIError::Unknown)
+        }
+    }
+
+    /// Send an unauthenticated GET request and return the raw bytes
+    pub(crate) async fn get_bytes(&self, url: &str) -> Result<Vec<u8>, EpicAPIError> {
+        let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .client
+            .get(parsed_url)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })?;
+        if response.status() == reqwest::StatusCode::OK {
+            response.bytes().await.map(|b| b.to_vec()).map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::Unknown
+            })
+        } else {
+            warn!(
+                "{} result: {}",
+                response.status(),
+                response.text().await.unwrap_or_default()
+            );
+            Err(EpicAPIError::Unknown)
+        }
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -13,6 +13,10 @@ pub mod types;
 /// Various API Utils
 pub mod utils;
 
+/// Binary reader/writer for manifest parsing
+#[allow(dead_code)]
+pub(crate) mod binary_rw;
+
 /// Error type
 pub mod error;
 
@@ -109,20 +113,18 @@ impl EpicAPI {
             .await
             .map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK {
             response.json::<T>().await.map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {
-            warn!(
-                "{} result: {}",
-                response.status(),
-                response.text().await.unwrap_or_default()
-            );
-            Err(EpicAPIError::Unknown)
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
         }
     }
 
@@ -140,20 +142,18 @@ impl EpicAPI {
             .await
             .map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK {
             response.json::<T>().await.map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {
-            warn!(
-                "{} result: {}",
-                response.status(),
-                response.text().await.unwrap_or_default()
-            );
-            Err(EpicAPIError::Unknown)
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
         }
     }
 
@@ -171,20 +171,18 @@ impl EpicAPI {
             .await
             .map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK {
             response.json::<T>().await.map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {
-            warn!(
-                "{} result: {}",
-                response.status(),
-                response.text().await.unwrap_or_default()
-            );
-            Err(EpicAPIError::Unknown)
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
         }
     }
 
@@ -198,20 +196,18 @@ impl EpicAPI {
             .await
             .map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK {
             response.bytes().await.map(|b| b.to_vec()).map_err(|e| {
                 error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {
-            warn!(
-                "{} result: {}",
-                response.status(),
-                response.text().await.unwrap_or_default()
-            );
-            Err(EpicAPIError::Unknown)
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
         }
     }
 }

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -1,0 +1,43 @@
+use crate::api::error::EpicAPIError;
+use crate::api::types::presence::PresenceUpdate;
+use crate::api::EpicAPI;
+
+impl EpicAPI {
+    /// Update user presence status.
+    pub async fn update_presence(
+        &self,
+        session_id: &str,
+        body: &PresenceUpdate,
+    ) -> Result<(), EpicAPIError> {
+        let id = match &self.user_data.account_id {
+            Some(id) => id.clone(),
+            None => return Err(EpicAPIError::InvalidCredentials),
+        };
+        let url = format!(
+            "https://presence-public-service-prod.ol.epicgames.com/presence/api/v1/_/{}/presence/{}",
+            id, session_id
+        );
+        let parsed_url = url::Url::parse(&url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .set_authorization_header(self.client.patch(parsed_url))
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| {
+                log::error!("{:?}", e);
+                EpicAPIError::Unknown
+            })?;
+        if response.status() == reqwest::StatusCode::OK
+            || response.status() == reqwest::StatusCode::NO_CONTENT
+        {
+            Ok(())
+        } else {
+            log::warn!(
+                "{} result: {}",
+                response.status(),
+                response.text().await.unwrap_or_default()
+            );
+            Err(EpicAPIError::Unknown)
+        }
+    }
+}

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -9,14 +9,13 @@ impl EpicAPI {
         session_id: &str,
         body: &PresenceUpdate,
     ) -> Result<(), EpicAPIError> {
-        let id = match &self.user_data.account_id {
-            Some(id) => id.clone(),
+        let url = match &self.user_data.account_id {
+            Some(id) => format!(
+                "https://presence-public-service-prod.ol.epicgames.com/presence/api/v1/_/{}/presence/{}",
+                id, session_id
+            ),
             None => return Err(EpicAPIError::InvalidCredentials),
         };
-        let url = format!(
-            "https://presence-public-service-prod.ol.epicgames.com/presence/api/v1/_/{}/presence/{}",
-            id, session_id
-        );
         let parsed_url = url::Url::parse(&url).map_err(|_| EpicAPIError::InvalidParams)?;
         let response = self
             .set_authorization_header(self.client.patch(parsed_url))

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -24,19 +24,17 @@ impl EpicAPI {
             .await
             .map_err(|e| {
                 log::error!("{:?}", e);
-                EpicAPIError::Unknown
+                EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK
             || response.status() == reqwest::StatusCode::NO_CONTENT
         {
             Ok(())
         } else {
-            log::warn!(
-                "{} result: {}",
-                response.status(),
-                response.text().await.unwrap_or_default()
-            );
-            Err(EpicAPIError::Unknown)
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            log::warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
         }
     }
 }

--- a/src/api/status.rs
+++ b/src/api/status.rs
@@ -1,0 +1,17 @@
+use crate::api::error::EpicAPIError;
+use crate::api::types::service_status::ServiceStatus;
+use crate::api::EpicAPI;
+
+impl EpicAPI {
+    /// Fetch bulk service status from the lightswitch API.
+    pub async fn service_status(
+        &self,
+        service_id: &str,
+    ) -> Result<Vec<ServiceStatus>, EpicAPIError> {
+        let url = format!(
+            "https://lightswitch-public-service-prod06.ol.epicgames.com/lightswitch/api/service/bulk/status?serviceId={}",
+            service_id
+        );
+        self.authorized_get_json(&url).await
+    }
+}

--- a/src/api/types/account.rs
+++ b/src/api/types/account.rs
@@ -1,6 +1,6 @@
-use std::collections::HashMap;
-use serde::{Deserialize, Serialize};
 use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Structure that holds all account data
 #[allow(missing_docs)]
@@ -157,6 +157,7 @@ impl UserData {
     }
 }
 
+/// Account info returned by bulk account ID lookup.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -180,6 +181,76 @@ pub struct ExternalAuth {
     #[serde(rename = "type")]
     pub type_field: String,
     pub external_auth_secondary_id: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_data_new_defaults() {
+        let ud = UserData::new();
+        assert_eq!(ud.access_token, None);
+        assert_eq!(ud.refresh_token, None);
+        assert_eq!(ud.account_id, None);
+        assert_eq!(ud.display_name, None);
+        assert_eq!(ud.expires_at, None);
+    }
+
+    #[test]
+    fn user_data_update_merges_some_fields() {
+        let mut ud = UserData::new();
+        ud.access_token = Some("old_token".to_string());
+        ud.account_id = Some("id123".to_string());
+
+        let mut new_ud = UserData::new();
+        new_ud.access_token = Some("new_token".to_string());
+        // account_id left as None
+
+        ud.update(new_ud);
+        assert_eq!(ud.access_token, Some("new_token".to_string()));
+        assert_eq!(ud.account_id, Some("id123".to_string()));
+    }
+
+    #[test]
+    fn user_data_update_all_none_preserves() {
+        let mut ud = UserData::new();
+        ud.access_token = Some("token".to_string());
+        ud.account_id = Some("id".to_string());
+        ud.display_name = Some("user".to_string());
+
+        let original = ud.clone();
+        ud.update(UserData::new());
+        assert_eq!(ud, original);
+    }
+
+    #[test]
+    fn user_data_serialization_roundtrip() {
+        let mut ud = UserData::new();
+        ud.access_token = Some("tok123".to_string());
+        ud.display_name = Some("TestUser".to_string());
+        ud.account_id = Some("acc456".to_string());
+
+        let json = serde_json::to_string(&ud).unwrap();
+        let deserialized: UserData = serde_json::from_str(&json).unwrap();
+        assert_eq!(ud, deserialized);
+    }
+
+    #[test]
+    fn user_data_access_token_getters() {
+        let mut ud = UserData::new();
+        assert_eq!(ud.access_token(), None);
+        ud.set_access_token(Some("my_token".to_string()));
+        assert_eq!(ud.access_token(), Some("my_token".to_string()));
+    }
+
+    #[test]
+    fn user_data_refresh_token_getters() {
+        let mut ud = UserData::new();
+        assert_eq!(ud.refresh_token(), None);
+        ud.set_refresh_token(Some("refresh_tok".to_string()));
+        assert_eq!(ud.refresh_token(), Some("refresh_tok".to_string()));
+    }
 }
 
 #[allow(missing_docs)]

--- a/src/api/types/account.rs
+++ b/src/api/types/account.rs
@@ -82,13 +82,13 @@ impl UserData {
     }
 
     /// Get access token
-    pub fn access_token(&self) -> Option<String> {
-        self.access_token.clone()
+    pub fn access_token(&self) -> Option<&str> {
+        self.access_token.as_deref()
     }
 
     /// Get refresh token
-    pub fn refresh_token(&self) -> Option<String> {
-        self.refresh_token.clone()
+    pub fn refresh_token(&self) -> Option<&str> {
+        self.refresh_token.as_deref()
     }
 
     /// Set access token
@@ -241,7 +241,7 @@ mod tests {
         let mut ud = UserData::new();
         assert_eq!(ud.access_token(), None);
         ud.set_access_token(Some("my_token".to_string()));
-        assert_eq!(ud.access_token(), Some("my_token".to_string()));
+        assert_eq!(ud.access_token(), Some("my_token"));
     }
 
     #[test]
@@ -249,7 +249,7 @@ mod tests {
         let mut ud = UserData::new();
         assert_eq!(ud.refresh_token(), None);
         ud.set_refresh_token(Some("refresh_tok".to_string()));
-        assert_eq!(ud.refresh_token(), Some("refresh_tok".to_string()));
+        assert_eq!(ud.refresh_token(), Some("refresh_tok"));
     }
 }
 

--- a/src/api/types/asset_info.rs
+++ b/src/api/types/asset_info.rs
@@ -56,7 +56,8 @@ impl AssetInfo {
 
     /// Get list of sorted releases newest to oldest
     pub fn sorted_releases(&self) -> Option<Vec<ReleaseInfo>> {
-        if let Some(mut release_info) = self.release_info.clone() {
+        if let Some(releases) = &self.release_info {
+            let mut release_info = releases.clone();
             release_info.sort_by_key(|ri| ri.date_added);
             release_info.reverse();
             Some(release_info)
@@ -67,10 +68,10 @@ impl AssetInfo {
 
     /// Get release info based on the release id
     pub fn release_info(&self, id: &str) -> Option<ReleaseInfo> {
-        if let Some(releases) = self.release_info.clone() {
+        if let Some(releases) = &self.release_info {
             for release in releases {
-                if release.id.clone().unwrap_or_default().eq(id) {
-                    return Some(release);
+                if release.id.as_deref().unwrap_or_default() == id {
+                    return Some(release.clone());
                 }
             }
         };
@@ -79,10 +80,10 @@ impl AssetInfo {
 
     /// Get release info based on the release name
     pub fn release_name(&self, name: &str) -> Option<ReleaseInfo> {
-        if let Some(releases) = self.release_info.clone() {
+        if let Some(releases) = &self.release_info {
             for release in releases {
-                if release.app_id.clone().unwrap_or_default().eq(name) {
-                    return Some(release);
+                if release.app_id.as_deref().unwrap_or_default() == name {
+                    return Some(release.clone());
                 }
             }
         };
@@ -96,7 +97,7 @@ impl AssetInfo {
             for info in release_infos {
                 match &info.compatible_apps {
                     None => {}
-                    Some(ca) => res.append(&mut ca.clone()),
+                    Some(ca) => res.extend(ca.iter().cloned()),
                 };
             }
             res.sort();
@@ -113,7 +114,7 @@ impl AssetInfo {
             for info in release_infos {
                 match &info.platform {
                     None => {}
-                    Some(p) => res.append(&mut p.clone()),
+                    Some(p) => res.extend(p.iter().cloned()),
                 };
             }
             res.sort();

--- a/src/api/types/asset_info.rs
+++ b/src/api/types/asset_info.rs
@@ -3,6 +3,7 @@ use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Detailed catalog metadata for an asset, including DLC list and release info.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -166,6 +167,7 @@ pub struct ReleaseInfo {
     pub version_title: Option<String>,
 }
 
+/// A short-lived exchange code for game launches.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -175,8 +177,155 @@ pub struct GameToken {
     pub creating_client_id: String,
 }
 
+/// JWT token proving ownership of an asset.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct OwnershipToken {
     pub token: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{Duration, Utc};
+
+    fn make_release(
+        id: &str,
+        app_id: &str,
+        days_ago: i64,
+        platforms: Vec<&str>,
+        compat: Vec<&str>,
+    ) -> ReleaseInfo {
+        ReleaseInfo {
+            id: Some(id.to_string()),
+            app_id: Some(app_id.to_string()),
+            date_added: Some(Utc::now() - Duration::days(days_ago)),
+            platform: if platforms.is_empty() {
+                None
+            } else {
+                Some(platforms.iter().map(|s| s.to_string()).collect())
+            },
+            compatible_apps: if compat.is_empty() {
+                None
+            } else {
+                Some(compat.iter().map(|s| s.to_string()).collect())
+            },
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn latest_release_returns_newest() {
+        let info = AssetInfo {
+            release_info: Some(vec![
+                make_release("old", "app_old", 30, vec![], vec![]),
+                make_release("new", "app_new", 1, vec![], vec![]),
+                make_release("mid", "app_mid", 15, vec![], vec![]),
+            ]),
+            ..Default::default()
+        };
+        let latest = info.latest_release().unwrap();
+        assert_eq!(latest.id, Some("new".to_string()));
+    }
+
+    #[test]
+    fn sorted_releases_order() {
+        let info = AssetInfo {
+            release_info: Some(vec![
+                make_release("old", "a", 30, vec![], vec![]),
+                make_release("new", "b", 1, vec![], vec![]),
+                make_release("mid", "c", 15, vec![], vec![]),
+            ]),
+            ..Default::default()
+        };
+        let sorted = info.sorted_releases().unwrap();
+        assert_eq!(sorted[0].id, Some("new".to_string()));
+        assert_eq!(sorted[1].id, Some("mid".to_string()));
+        assert_eq!(sorted[2].id, Some("old".to_string()));
+    }
+
+    #[test]
+    fn latest_release_none_when_no_releases() {
+        let info = AssetInfo {
+            release_info: None,
+            ..Default::default()
+        };
+        assert!(info.latest_release().is_none());
+    }
+
+    #[test]
+    fn release_info_by_id() {
+        let info = AssetInfo {
+            release_info: Some(vec![
+                make_release("r1", "a", 10, vec![], vec![]),
+                make_release("r2", "b", 5, vec![], vec![]),
+            ]),
+            ..Default::default()
+        };
+        assert_eq!(
+            info.release_info("r2").unwrap().app_id,
+            Some("b".to_string())
+        );
+        assert!(info.release_info("nonexistent").is_none());
+    }
+
+    #[test]
+    fn release_name_lookup() {
+        let info = AssetInfo {
+            release_info: Some(vec![
+                make_release("r1", "MyApp", 10, vec![], vec![]),
+                make_release("r2", "OtherApp", 5, vec![], vec![]),
+            ]),
+            ..Default::default()
+        };
+        assert_eq!(
+            info.release_name("OtherApp").unwrap().id,
+            Some("r2".to_string())
+        );
+        assert!(info.release_name("Missing").is_none());
+    }
+
+    #[test]
+    fn compatible_apps_deduplicates() {
+        let info = AssetInfo {
+            release_info: Some(vec![
+                make_release("r1", "a", 10, vec![], vec!["UE_5.0", "UE_4.27"]),
+                make_release("r2", "b", 5, vec![], vec!["UE_5.0", "UE_5.1"]),
+            ]),
+            ..Default::default()
+        };
+        let apps = info.compatible_apps().unwrap();
+        assert_eq!(apps, vec!["UE_4.27", "UE_5.0", "UE_5.1"]);
+    }
+
+    #[test]
+    fn compatible_apps_none_when_no_releases() {
+        let info = AssetInfo {
+            release_info: None,
+            ..Default::default()
+        };
+        assert!(info.compatible_apps().is_none());
+    }
+
+    #[test]
+    fn platforms_aggregates() {
+        let info = AssetInfo {
+            release_info: Some(vec![
+                make_release("r1", "a", 10, vec!["Windows"], vec![]),
+                make_release("r2", "b", 5, vec!["Windows", "Mac"], vec![]),
+            ]),
+            ..Default::default()
+        };
+        let plats = info.platforms().unwrap();
+        assert_eq!(plats, vec!["Mac", "Windows"]);
+    }
+
+    #[test]
+    fn platforms_none_when_no_releases() {
+        let info = AssetInfo {
+            release_info: None,
+            ..Default::default()
+        };
+        assert!(info.platforms().is_none());
+    }
 }

--- a/src/api/types/asset_manifest.rs
+++ b/src/api/types/asset_manifest.rs
@@ -1,6 +1,7 @@
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 
+/// Response from the asset manifest endpoint, containing CDN download URLs.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct AssetManifest {
@@ -24,6 +25,7 @@ impl AssetManifest {
     }
 }
 
+/// A single build element within an asset manifest.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -35,6 +37,7 @@ pub struct Element {
     pub manifests: Vec<Manifest>,
 }
 
+/// A CDN manifest URL with authentication query parameters.
 #[allow(missing_docs)]
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/api/types/billing_account.rs
+++ b/src/api/types/billing_account.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+/// Default billing account for payment processing.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BillingAccount {
+    pub id: Option<String>,
+    pub country: Option<String>,
+}

--- a/src/api/types/catalog_item.rs
+++ b/src/api/types/catalog_item.rs
@@ -1,0 +1,42 @@
+use serde::{Deserialize, Serialize};
+
+/// Paginated response for catalog items within a namespace.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogItemPage {
+    #[serde(default)]
+    pub elements: Vec<CatalogItem>,
+    pub paging: Option<Paging>,
+}
+
+/// A single catalog item entry.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogItem {
+    pub id: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub namespace: Option<String>,
+    pub status: Option<String>,
+    pub creation_date: Option<String>,
+    pub last_modified_date: Option<String>,
+    pub entitlement_name: Option<String>,
+    pub entitlement_type: Option<String>,
+    pub item_type: Option<String>,
+    pub developer: Option<String>,
+    pub developer_id: Option<String>,
+    pub end_of_support: Option<bool>,
+    pub unsearchable: Option<bool>,
+}
+
+/// Pagination metadata for catalog responses.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Paging {
+    pub count: i64,
+    pub start: i64,
+    pub total: i64,
+}

--- a/src/api/types/catalog_offer.rs
+++ b/src/api/types/catalog_offer.rs
@@ -1,0 +1,60 @@
+use serde::{Deserialize, Serialize};
+
+/// Paginated response for catalog offers within a namespace.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogOfferPage {
+    #[serde(default)]
+    pub elements: Vec<CatalogOffer>,
+    pub paging: Option<super::catalog_item::Paging>,
+}
+
+/// A single catalog offer entry.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CatalogOffer {
+    pub id: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub namespace: Option<String>,
+    pub status: Option<String>,
+    pub creation_date: Option<String>,
+    pub last_modified_date: Option<String>,
+    pub offer_type: Option<String>,
+    pub effective_date: Option<String>,
+    pub expiry_date: Option<String>,
+    pub is_code_redemption_only: Option<bool>,
+    pub seller: Option<Seller>,
+    #[serde(default)]
+    pub categories: Vec<OfferCategory>,
+    #[serde(default)]
+    pub items: Vec<OfferItem>,
+}
+
+/// Seller information on a catalog offer.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Seller {
+    pub id: String,
+    pub name: Option<String>,
+}
+
+/// Category attached to a catalog offer.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OfferCategory {
+    pub path: String,
+}
+
+/// Item reference within a catalog offer.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OfferItem {
+    pub id: String,
+    pub namespace: Option<String>,
+}

--- a/src/api/types/chunk.rs
+++ b/src/api/types/chunk.rs
@@ -65,11 +65,95 @@ impl Chunk {
         res.data = if res.compressed {
             let mut z = ZlibDecoder::new(&buffer[position..]);
             let mut data: Vec<u8> = Vec::new();
-            z.read_to_end(&mut data).unwrap();
+            if z.read_to_end(&mut data).is_err() {
+                error!("Failed to decompress chunk data");
+                return None;
+            }
             data
         } else {
             buffer[position..].to_vec()
         };
         Some(res)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use flate2::write::ZlibEncoder;
+    use flate2::Compression;
+    use std::io::Write;
+
+    #[test]
+    fn from_vec_wrong_magic() {
+        let buffer = vec![0u8; 45];
+        assert_eq!(Chunk::from_vec(buffer), None);
+    }
+
+    #[test]
+    fn from_vec_valid_uncompressed() {
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.extend_from_slice(&2986228386u32.to_le_bytes());
+        buffer.extend_from_slice(&1u32.to_le_bytes());
+        buffer.extend_from_slice(&40u32.to_le_bytes());
+        buffer.extend_from_slice(&5u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&42u64.to_le_bytes());
+        buffer.push(0u8);
+        buffer.extend_from_slice(&[1, 2, 3, 4, 5]);
+
+        let chunk = Chunk::from_vec(buffer).unwrap();
+        assert!(chunk.guid.starts_with("00000000"));
+        assert_eq!(chunk.hash, 42);
+        assert_eq!(chunk.data, vec![1, 2, 3, 4, 5]);
+        assert_eq!(chunk.compressed, false);
+    }
+
+    #[test]
+    fn from_vec_valid_compressed() {
+        let mut encoder = ZlibEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(&[10, 20, 30]).unwrap();
+        let compressed = encoder.finish().unwrap();
+
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.extend_from_slice(&2986228386u32.to_le_bytes());
+        buffer.extend_from_slice(&1u32.to_le_bytes());
+        buffer.extend_from_slice(&40u32.to_le_bytes());
+        buffer.extend_from_slice(&(compressed.len() as u32).to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&42u64.to_le_bytes());
+        buffer.push(1u8);
+        buffer.extend_from_slice(&compressed);
+
+        let chunk = Chunk::from_vec(buffer).unwrap();
+        assert_eq!(chunk.data, vec![10, 20, 30]);
+    }
+
+    #[test]
+    fn from_vec_version2_has_sha() {
+        let mut buffer: Vec<u8> = Vec::new();
+        buffer.extend_from_slice(&2986228386u32.to_le_bytes());
+        buffer.extend_from_slice(&2u32.to_le_bytes());
+        buffer.extend_from_slice(&40u32.to_le_bytes());
+        buffer.extend_from_slice(&5u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&0u32.to_le_bytes());
+        buffer.extend_from_slice(&42u64.to_le_bytes());
+        buffer.push(0u8);
+        buffer.extend_from_slice(&[0xAB; 20]);
+        buffer.push(2u8);
+        buffer.extend_from_slice(&[1, 2, 3, 4, 5]);
+
+        let chunk = Chunk::from_vec(buffer).unwrap();
+        assert_eq!(chunk.sha_hash, Some(vec![0xAB; 20]));
+        assert_eq!(chunk.hash_type, Some(2));
     }
 }

--- a/src/api/types/currency.rs
+++ b/src/api/types/currency.rs
@@ -1,0 +1,24 @@
+use serde::{Deserialize, Serialize};
+
+/// Paginated response for currencies.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CurrencyPage {
+    #[serde(default)]
+    pub elements: Vec<Currency>,
+    pub paging: Option<super::catalog_item::Paging>,
+}
+
+/// A single currency entry.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Currency {
+    pub r#type: String,
+    pub code: String,
+    pub symbol: Option<String>,
+    pub description: Option<String>,
+    pub decimals: Option<i32>,
+    pub truncation_length: Option<i32>,
+}

--- a/src/api/types/download_manifest.rs
+++ b/src/api/types/download_manifest.rs
@@ -1,3 +1,4 @@
+use crate::api::binary_rw::{BinaryReader, BinaryWriter};
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
 use flate2::Compression;
@@ -5,7 +6,6 @@ use log::{debug, error, warn};
 use reqwest::Url;
 use serde::{de, Deserialize, Serialize};
 use sha1::{Digest, Sha1};
-use std::borrow::BorrowMut;
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::fmt;
@@ -187,27 +187,24 @@ fn parse_header(buffer: &[u8]) -> Option<(Vec<u8>, usize, u32)> {
     Some((data, position_after_header, header_size))
 }
 
-fn parse_meta(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
-    let meta_size = crate::api::utils::read_le(buffer, position);
+fn parse_meta(reader: &mut BinaryReader<'_>, res: &mut DownloadManifest) -> u32 {
+    let meta_size = reader.read_u32().unwrap_or(0);
 
-    let data_version = buffer[*position];
-    *position += 1;
+    let data_version = reader.read_u8().unwrap_or(0);
 
-    res.manifest_file_version = crate::api::utils::read_le(buffer, position).into();
+    res.manifest_file_version = reader.read_u32().unwrap_or(0).into();
 
-    res.b_is_file_data = !matches!(buffer[*position], 0);
-    *position += 1;
-    res.app_id = crate::api::utils::read_le(buffer, position) as u128;
-    res.app_name_string = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
-    res.build_version_string =
-        crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
-    res.launch_exe_string = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
-    res.launch_command = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    res.b_is_file_data = !matches!(reader.read_u8().unwrap_or(0), 0);
+    res.app_id = reader.read_u32().unwrap_or(0) as u128;
+    res.app_name_string = reader.read_fstring().unwrap_or_default();
+    res.build_version_string = reader.read_fstring().unwrap_or_default();
+    res.launch_exe_string = reader.read_fstring().unwrap_or_default();
+    res.launch_command = reader.read_fstring().unwrap_or_default();
 
-    let entries = crate::api::utils::read_le(buffer, position);
+    let entries = reader.read_u32().unwrap_or(0);
     let mut prereq_ids: Vec<String> = Vec::new();
     for _ in 0..entries {
-        if let Some(s) = crate::api::utils::read_fstring(buffer, position) {
+        if let Some(s) = reader.read_fstring() {
             prereq_ids.push(s)
         }
     }
@@ -217,49 +214,39 @@ fn parse_meta(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -
         res.prereq_ids = Some(prereq_ids);
     }
 
-    res.prereq_name = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
-    res.prereq_path = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
-    res.prereq_args = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    res.prereq_name = reader.read_fstring().unwrap_or_default();
+    res.prereq_path = reader.read_fstring().unwrap_or_default();
+    res.prereq_args = reader.read_fstring().unwrap_or_default();
 
     if data_version >= 1 {
-        res.build_version_string =
-            crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+        res.build_version_string = reader.read_fstring().unwrap_or_default();
     }
     if data_version >= 2 {
-        res.uninstall_action_path =
-            Some(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
-        res.uninstall_action_args =
-            Some(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
+        res.uninstall_action_path = Some(reader.read_fstring().unwrap_or_default());
+        res.uninstall_action_args = Some(reader.read_fstring().unwrap_or_default());
     }
 
-    debug!("Manifest end position {}", position);
+    debug!("Manifest end position {}", reader.position());
 
     meta_size
 }
 
-fn parse_chunks(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
-    let chunk_size = crate::api::utils::read_le(buffer, position);
+fn parse_chunks(reader: &mut BinaryReader<'_>, res: &mut DownloadManifest) -> u32 {
+    let chunk_size = reader.read_u32().unwrap_or(0);
     debug!("Chunk size {}", chunk_size);
 
-    let _version = buffer[*position];
+    let _version = reader.read_u8().unwrap_or(0);
     debug!("version: {}", _version);
-    *position += 1;
 
-    debug!("Chunk count at position: {}", position);
-    let count = crate::api::utils::read_le(buffer, position);
+    debug!("Chunk count at position: {}", reader.position());
+    let count = reader.read_u32().unwrap_or(0);
     debug!("Reading {} chunks", count);
 
     let mut chunks: Vec<BinaryChunkInfo> = Vec::new();
     for _i in 0..count {
         chunks.push(BinaryChunkInfo {
             manifest_version: res.manifest_file_version,
-            guid: format!(
-                "{:08x}{:08x}{:08x}{:08x}",
-                crate::api::utils::read_le(buffer, position),
-                crate::api::utils::read_le(buffer, position),
-                crate::api::utils::read_le(buffer, position),
-                crate::api::utils::read_le(buffer, position)
-            ),
+            guid: reader.read_guid().unwrap_or_default(),
             hash: 0,
             sha_hash: Vec::new(),
             group_num: 0,
@@ -270,24 +257,22 @@ fn parse_chunks(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest)
 
     debug!("Reading Chunk Hashes");
     for chunk in chunks.iter_mut() {
-        chunk.hash = crate::api::utils::read_le_64(buffer, position) as u128;
+        chunk.hash = reader.read_u64().unwrap_or(0) as u128;
     }
     debug!("Reading Chunk Sha Hashes");
     for chunk in chunks.iter_mut() {
-        *position += 20;
-        chunk.sha_hash = buffer[*position - 20..*position].into();
+        chunk.sha_hash = reader.read_bytes(20).unwrap_or(&[0u8; 20]).into();
     }
 
     debug!("Reading Chunk group nums");
     for chunk in chunks.iter_mut() {
-        chunk.group_num = buffer[*position];
-        *position += 1;
+        chunk.group_num = reader.read_u8().unwrap_or(0);
     }
     for chunk in chunks.iter_mut() {
-        chunk.window_size = crate::api::utils::read_le(buffer, position);
+        chunk.window_size = reader.read_u32().unwrap_or(0);
     }
     for chunk in chunks.iter_mut() {
-        chunk.file_size = crate::api::utils::read_le_64_signed(buffer, position);
+        chunk.file_size = reader.read_i64().unwrap_or(0);
     }
 
     let mut chunk_sha_list: HashMap<String, String> = HashMap::new();
@@ -312,18 +297,17 @@ fn parse_chunks(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest)
     chunk_size
 }
 
-fn parse_files(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
-    let filemanifest_size = crate::api::utils::read_le(buffer, position);
+fn parse_files(reader: &mut BinaryReader<'_>, res: &mut DownloadManifest) -> u32 {
+    let filemanifest_size = reader.read_u32().unwrap_or(0);
 
-    let fm_version = buffer[*position];
+    let fm_version = reader.read_u8().unwrap_or(0);
     debug!("File manifest version: {}", fm_version);
-    *position += 1;
-    let count = crate::api::utils::read_le(buffer, position);
+    let count = reader.read_u32().unwrap_or(0);
 
     let mut files: Vec<BinaryFileManifest> = Vec::new();
     for _ in 0..count {
         files.push(BinaryFileManifest {
-            filename: crate::api::utils::read_fstring(buffer, position).unwrap_or_default(),
+            filename: reader.read_fstring().unwrap_or_default(),
             symlink_target: "".to_string(),
             hash: vec![],
             hash_md5: vec![],
@@ -337,52 +321,44 @@ fn parse_files(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) 
     }
 
     for file in files.iter_mut() {
-        file.symlink_target = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+        file.symlink_target = reader.read_fstring().unwrap_or_default();
     }
 
     for file in files.iter_mut() {
-        *position += 20;
-        file.hash = buffer[*position - 20..*position].into();
+        file.hash = reader.read_bytes(20).unwrap_or(&[0u8; 20]).into();
     }
 
     for file in files.iter_mut() {
-        file.flags = buffer[*position];
-        *position += 1;
+        file.flags = reader.read_u8().unwrap_or(0);
     }
 
     for file in files.iter_mut() {
-        let elem_count = crate::api::utils::read_le(buffer, position);
+        let elem_count = reader.read_u32().unwrap_or(0);
         for _ in 0..elem_count {
             file.install_tags
-                .push(crate::api::utils::read_fstring(buffer, position).unwrap_or_default())
+                .push(reader.read_fstring().unwrap_or_default())
         }
     }
 
     // File Chunks
     for i in 0..count {
         if let Some(file) = files.get_mut(i as usize) {
-            let elem_count = crate::api::utils::read_le(buffer, position);
+            let elem_count = reader.read_u32().unwrap_or(0);
             let mut offset: u128 = 0;
             for _i in 0..elem_count {
-                let total = *position;
-                let chunk_size = crate::api::utils::read_le(buffer, position);
+                let total = reader.position();
+                let chunk_size = reader.read_u32().unwrap_or(0);
                 let chunk = BinaryChunkPart {
-                    guid: format!(
-                        "{:08x}{:08x}{:08x}{:08x}",
-                        crate::api::utils::read_le(buffer, position),
-                        crate::api::utils::read_le(buffer, position),
-                        crate::api::utils::read_le(buffer, position),
-                        crate::api::utils::read_le(buffer, position)
-                    ),
-                    offset: crate::api::utils::read_le(buffer, position) as u128,
-                    size: crate::api::utils::read_le(buffer, position) as u128,
+                    guid: reader.read_guid().unwrap_or_default(),
+                    offset: reader.read_u32().unwrap_or(0) as u128,
+                    size: reader.read_u32().unwrap_or(0) as u128,
                     file_offset: offset,
                 };
                 offset += chunk.size;
-                let diff = *position - total - chunk_size as usize;
+                let diff = reader.position() - total - chunk_size as usize;
                 if diff > 0 {
                     warn!("Did not read the entire chunk part!");
-                    *position += diff
+                    let _ = reader.skip(diff);
                 }
                 file.chunk_parts.push(chunk);
             }
@@ -391,21 +367,19 @@ fn parse_files(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) 
 
     if fm_version >= 1 {
         for file in files.iter_mut() {
-            let has_md5 = crate::api::utils::read_le(buffer, position);
+            let has_md5 = reader.read_u32().unwrap_or(0);
             if has_md5 != 0 {
-                *position += 16;
-                file.hash_md5 = buffer[*position - 16..*position].into();
+                file.hash_md5 = reader.read_bytes(16).unwrap_or(&[0u8; 16]).into();
             }
         }
         for file in files.iter_mut() {
-            file.mime_type = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+            file.mime_type = reader.read_fstring().unwrap_or_default();
         }
     }
 
     if fm_version >= 2 {
         for file in files.iter_mut() {
-            *position += 32;
-            file.hash_sha256 = buffer[*position - 32..*position].into();
+            file.hash_sha256 = reader.read_bytes(32).unwrap_or(&[0u8; 32]).into();
         }
     }
 
@@ -436,22 +410,21 @@ fn parse_files(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) 
     filemanifest_size
 }
 
-fn parse_custom_fields(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
-    let size = crate::api::utils::read_le(buffer, position);
+fn parse_custom_fields(reader: &mut BinaryReader<'_>, res: &mut DownloadManifest) -> u32 {
+    let size = reader.read_u32().unwrap_or(0);
 
-    let _version = buffer[*position];
-    *position += 1;
-    let count = crate::api::utils::read_le(buffer, position);
+    let _version = reader.read_u8().unwrap_or(0);
+    let count = reader.read_u32().unwrap_or(0);
 
     let mut keys: Vec<String> = Vec::new();
     let mut values: Vec<String> = Vec::new();
 
     for _ in 0..count {
-        keys.push(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
+        keys.push(reader.read_fstring().unwrap_or_default());
     }
 
     for _ in 0..count {
-        values.push(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
+        values.push(reader.read_fstring().unwrap_or_default());
     }
 
     let mut custom_fields: HashMap<String, String> = HashMap::new();
@@ -649,49 +622,50 @@ impl DownloadManifest {
         };
 
         // Reading Header
-        let (buffer, mut position, header_size) = parse_header(buffer)?;
+        let (buffer, position_after_header, header_size) = parse_header(buffer)?;
+        let mut reader = BinaryReader::with_position(&buffer, position_after_header);
 
         // Manifest Meta
-        let meta_size = parse_meta(&buffer, &mut position, &mut res);
+        let meta_size = parse_meta(&mut reader, &mut res);
 
         debug!(
             "Manifest metadata read length(needs to match {}): {}",
             meta_size,
-            position - header_size as usize
+            reader.position() - header_size as usize
         );
 
         // Chunks
-        let chunk_size = parse_chunks(&buffer, &mut position, &mut res);
+        let chunk_size = parse_chunks(&mut reader, &mut res);
 
         debug!(
             "Chunks read length(needs to match {}): {}",
             chunk_size,
-            position - meta_size as usize - header_size as usize
+            reader.position() - meta_size as usize - header_size as usize
         );
 
         // File Manifest
-        let filemanifest_size = parse_files(&buffer, &mut position, &mut res);
+        let filemanifest_size = parse_files(&mut reader, &mut res);
 
         debug!(
             "File Manifests read length(needs to match {}): {}",
             filemanifest_size,
-            position - meta_size as usize - header_size as usize - chunk_size as usize
+            reader.position() - meta_size as usize - header_size as usize - chunk_size as usize
         );
 
         // Custom Fields
-        let size = parse_custom_fields(&buffer, &mut position, &mut res);
+        let size = parse_custom_fields(&mut reader, &mut res);
 
         debug!(
             "Custom fields read length(needs to match {}): {}",
             size,
-            position
+            reader.position()
                 - meta_size as usize
                 - header_size as usize
                 - chunk_size as usize
                 - filemanifest_size as usize
         );
 
-        if position
+        if reader.position()
             - meta_size as usize
             - header_size as usize
             - chunk_size as usize
@@ -706,107 +680,79 @@ impl DownloadManifest {
     }
 
     fn write_meta(&self) -> Vec<u8> {
-        let mut data: Vec<u8> = Vec::new();
-        let mut meta: Vec<u8> = Vec::new();
+        let mut writer = BinaryWriter::new();
         // Data version
-        meta.push(if self.build_version_string.is_empty() {
+        writer.write_u8(if self.build_version_string.is_empty() {
             0
         } else {
             1
         });
         // Feature level
         match u32::try_from(self.manifest_file_version) {
-            Ok(version) => meta.append(version.to_le_bytes().to_vec().borrow_mut()),
-            Err(_) => meta.append(18u32.to_le_bytes().to_vec().borrow_mut()),
+            Ok(version) => writer.write_u32(version),
+            Err(_) => writer.write_u32(18u32),
         }
         // is file data
-        meta.push(0);
+        writer.write_u8(0);
         // app id
         match u32::try_from(self.app_id) {
-            Ok(version) => meta.append(version.to_le_bytes().to_vec().borrow_mut()),
-            Err(_) => meta.append(0u32.to_le_bytes().to_vec().borrow_mut()),
+            Ok(version) => writer.write_u32(version),
+            Err(_) => writer.write_u32(0u32),
         }
 
-        meta.append(crate::api::utils::write_fstring(&self.app_name_string).borrow_mut());
+        writer.write_fstring(&self.app_name_string);
 
-        meta.append(crate::api::utils::write_fstring(&self.build_version_string).borrow_mut());
+        writer.write_fstring(&self.build_version_string);
 
-        meta.append(crate::api::utils::write_fstring(&self.launch_exe_string).borrow_mut());
+        writer.write_fstring(&self.launch_exe_string);
 
-        meta.append(crate::api::utils::write_fstring(&self.launch_command).borrow_mut());
+        writer.write_fstring(&self.launch_command);
 
         match &self.prereq_ids {
-            None => meta.append(0u32.to_le_bytes().to_vec().borrow_mut()),
+            None => writer.write_u32(0u32),
             Some(prereq_ids) => {
-                meta.append(
-                    (prereq_ids.len() as u32)
-                        .to_le_bytes()
-                        .to_vec()
-                        .borrow_mut(),
-                );
+                writer.write_u32(prereq_ids.len() as u32);
                 for prereq_id in prereq_ids {
-                    meta.append(crate::api::utils::write_fstring(prereq_id).borrow_mut());
+                    writer.write_fstring(prereq_id);
                 }
             }
         }
 
-        meta.append(crate::api::utils::write_fstring(&self.prereq_name).borrow_mut());
+        writer.write_fstring(&self.prereq_name);
 
-        meta.append(crate::api::utils::write_fstring(&self.prereq_path).borrow_mut());
+        writer.write_fstring(&self.prereq_path);
 
-        meta.append(crate::api::utils::write_fstring(&self.prereq_args).borrow_mut());
+        writer.write_fstring(&self.prereq_args);
 
         if !self.build_version_string.is_empty() {
-            meta.append(crate::api::utils::write_fstring(&self.build_version_string).borrow_mut());
+            writer.write_fstring(&self.build_version_string);
         }
         // Meta Size
-        data.append(
-            ((meta.len() + 4) as u32)
-                .to_le_bytes()
-                .to_vec()
-                .borrow_mut(),
-        );
-        data.append(meta.borrow_mut());
-        data
+        let inner = writer.into_vec();
+        let mut result = BinaryWriter::new();
+        result.write_u32((inner.len() + 4) as u32);
+        result.write_bytes(&inner);
+        result.into_vec()
     }
 
     fn write_chunks(&self) -> Vec<u8> {
-        let mut data: Vec<u8> = Vec::new();
         // version
-        let mut chunks: Vec<u8> = vec![0];
+        let mut writer = BinaryWriter::new();
+        writer.write_u8(0);
 
         // count
-        chunks.append(
-            (self.chunk_hash_list.len() as u32)
-                .to_le_bytes()
-                .to_vec()
-                .borrow_mut(),
-        );
+        writer.write_u32(self.chunk_hash_list.len() as u32);
 
         for chunk in self.chunk_hash_list.keys() {
-            let subs = chunk
-                .as_bytes()
-                .chunks(8)
-                .map(std::str::from_utf8)
-                .collect::<Result<Vec<&str>, _>>()
-                .unwrap();
-            for g in subs {
-                chunks.append(
-                    u32::from_str_radix(g, 16)
-                        .unwrap()
-                        .to_le_bytes()
-                        .to_vec()
-                        .borrow_mut(),
-                )
-            }
+            writer.write_guid(chunk);
         }
 
         // TODO: PROBABLY SORT THE CHUNKS SO WE GUARANTEE THE ORDER
 
         for hash in self.chunk_hash_list.values() {
             match u64::try_from(*hash) {
-                Ok(h) => chunks.append(h.to_le_bytes().to_vec().borrow_mut()),
-                Err(_) => chunks.append((0_u64).to_le_bytes().to_vec().borrow_mut()),
+                Ok(h) => writer.write_u64(h),
+                Err(_) => writer.write_u64(0_u64),
             }
         }
 
@@ -817,194 +763,136 @@ impl DownloadManifest {
             .values()
         {
             match crate::api::utils::decode_hex(sha.as_str()) {
-                Ok(mut s) => chunks.append(s.borrow_mut()),
-                Err(_) => chunks.append(vec![0u8; 20].borrow_mut()),
+                Ok(s) => writer.write_bytes(&s),
+                Err(_) => writer.write_bytes(&[0u8; 20]),
             }
         }
 
         for group in self.data_group_list.values() {
-            chunks.append(
-                u8::try_from(*group)
-                    .unwrap_or_default()
-                    .to_le_bytes()
-                    .to_vec()
-                    .borrow_mut(),
-            )
+            writer.write_u8(u8::try_from(*group).unwrap_or_default());
         }
 
         // TODO: THIS IS WRONG THIS SHOULD BE UNCOMPRESSED SIZE, CAN BE PROBABLY GOT FROM THE FILE MANIFEST
         for window in self.chunk_filesize_list.values() {
-            chunks.append(
-                u32::try_from(*window)
-                    .unwrap_or_default()
-                    .to_le_bytes()
-                    .to_vec()
-                    .borrow_mut(),
-            )
+            writer.write_u32(u32::try_from(*window).unwrap_or_default());
         }
         // File Size
         for file in self.chunk_filesize_list.values() {
-            chunks.append(
-                i64::try_from(*file)
-                    .unwrap_or_default()
-                    .to_le_bytes()
-                    .to_vec()
-                    .borrow_mut(),
-            )
+            writer.write_i64(i64::try_from(*file).unwrap_or_default());
         }
 
         // Adding chunks to data
         // add chunk size
-        data.append(
-            ((chunks.len() + 4) as u32)
-                .to_le_bytes()
-                .to_vec()
-                .borrow_mut(),
-        );
-        data.append(chunks.borrow_mut());
-        data
+        let inner = writer.into_vec();
+        let mut result = BinaryWriter::new();
+        result.write_u32((inner.len() + 4) as u32);
+        result.write_bytes(&inner);
+        result.into_vec()
     }
 
     fn write_files(&self) -> Vec<u8> {
-        let mut data: Vec<u8> = Vec::new();
         // version
-        let mut files: Vec<u8> = vec![0];
+        let mut writer = BinaryWriter::new();
+        writer.write_u8(0);
 
         // count
-        files.append(
-            (self.file_manifest_list.len() as u32)
-                .to_le_bytes()
-                .to_vec()
-                .borrow_mut(),
-        );
+        writer.write_u32(self.file_manifest_list.len() as u32);
 
         // Filenames
         for file in &self.file_manifest_list {
-            files.append(crate::api::utils::write_fstring(&file.filename).borrow_mut());
+            writer.write_fstring(&file.filename);
         }
 
         // Symlink target
         // TODO: Figure out what Epic puts in theirs
         for _ in &self.file_manifest_list {
-            files.append(crate::api::utils::write_fstring("").borrow_mut());
+            writer.write_fstring("");
         }
 
         // hash
         for file in &self.file_manifest_list {
             match crate::api::utils::decode_hex(file.file_hash.as_str()) {
-                Ok(mut s) => files.append(s.borrow_mut()),
-                Err(_) => files.append(vec![0u8; 20].borrow_mut()),
+                Ok(s) => writer.write_bytes(&s),
+                Err(_) => writer.write_bytes(&[0u8; 20]),
             }
         }
 
         // flags
         // TODO: Figure out what Epic puts in theirs
         for _ in &self.file_manifest_list {
-            files.push(0u8);
+            writer.write_u8(0u8);
         }
 
         // install tags
         // TODO: Figure out what Epic puts in theirs
         for _ in &self.file_manifest_list {
-            files.append(0u32.to_le_bytes().to_vec().borrow_mut());
+            writer.write_u32(0u32);
             // files.append(crate::api::utils::write_fstring("".to_string()).borrow_mut());
         }
 
         // File Chunks
         for file in &self.file_manifest_list {
-            files.append(
-                (file.file_chunk_parts.len() as u32)
-                    .to_le_bytes()
-                    .to_vec()
-                    .borrow_mut(),
-            );
+            writer.write_u32(file.file_chunk_parts.len() as u32);
             for chunk_part in &file.file_chunk_parts {
-                files.append(28u32.to_le_bytes().to_vec().borrow_mut());
-                let subs = chunk_part
-                    .guid
-                    .as_bytes()
-                    .chunks(8)
-                    .map(std::str::from_utf8)
-                    .collect::<Result<Vec<&str>, _>>()
-                    .unwrap();
-                for g in subs {
-                    files.append(
-                        u32::from_str_radix(g, 16)
-                            .unwrap()
-                            .to_le_bytes()
-                            .to_vec()
-                            .borrow_mut(),
-                    )
-                }
+                writer.write_u32(28u32);
+                writer.write_guid(&chunk_part.guid);
                 match u32::try_from(chunk_part.offset) {
-                    Ok(offset) => files.append(offset.to_le_bytes().to_vec().borrow_mut()),
-                    Err(_) => files.append(0u32.to_le_bytes().to_vec().borrow_mut()),
+                    Ok(offset) => writer.write_u32(offset),
+                    Err(_) => writer.write_u32(0u32),
                 }
                 match u32::try_from(chunk_part.size) {
-                    Ok(size) => files.append(size.to_le_bytes().to_vec().borrow_mut()),
-                    Err(_) => files.append(0u32.to_le_bytes().to_vec().borrow_mut()),
+                    Ok(size) => writer.write_u32(size),
+                    Err(_) => writer.write_u32(0u32),
                 }
             }
         }
 
         // Adding File manifest to data
-        data.append(
-            ((files.len() + 4) as u32)
-                .to_le_bytes()
-                .to_vec()
-                .borrow_mut(),
-        );
-        data.append(files.borrow_mut());
-        data
+        let inner = writer.into_vec();
+        let mut result = BinaryWriter::new();
+        result.write_u32((inner.len() + 4) as u32);
+        result.write_bytes(&inner);
+        result.into_vec()
     }
 
     fn write_custom_fields(&self) -> Vec<u8> {
-        let mut data: Vec<u8> = Vec::new();
         // version
-        let mut custom: Vec<u8> = vec![0];
+        let mut writer = BinaryWriter::new();
+        writer.write_u8(0);
 
         match &self.custom_fields {
             None => {
-                custom.push(0);
+                writer.write_u8(0);
             }
             Some(custom_fields) => {
                 // count
-                custom.append(
-                    (custom_fields.len() as u32)
-                        .to_le_bytes()
-                        .to_vec()
-                        .borrow_mut(),
-                );
+                writer.write_u32(custom_fields.len() as u32);
 
                 for key in custom_fields.keys() {
-                    custom.append(crate::api::utils::write_fstring(key).borrow_mut());
+                    writer.write_fstring(key);
                 }
                 for value in custom_fields.values() {
-                    custom.append(crate::api::utils::write_fstring(value).borrow_mut());
+                    writer.write_fstring(value);
                 }
             }
         }
 
         // Adding Custom Feilds to data
-        data.append(
-            ((custom.len() + 4) as u32)
-                .to_le_bytes()
-                .to_vec()
-                .borrow_mut(),
-        );
-        data.append(custom.borrow_mut());
-        data
+        let inner = writer.into_vec();
+        let mut result = BinaryWriter::new();
+        result.write_u32((inner.len() + 4) as u32);
+        result.write_bytes(&inner);
+        result.into_vec()
     }
 
     /// Return a vector containing the manifest data
     pub fn to_vec(&self) -> Vec<u8> {
-        let mut result: Vec<u8> = Vec::new();
-
-        let mut data: Vec<u8> = Vec::new();
-        data.append(self.write_meta().borrow_mut());
-        data.append(self.write_chunks().borrow_mut());
-        data.append(self.write_files().borrow_mut());
-        data.append(self.write_custom_fields().borrow_mut());
+        let mut data = BinaryWriter::new();
+        data.write_bytes(&self.write_meta());
+        data.write_bytes(&self.write_chunks());
+        data.write_bytes(&self.write_files());
+        data.write_bytes(&self.write_custom_fields());
+        let data = data.into_vec();
 
         // FINISHING METADATA (Probably done)
 
@@ -1012,29 +900,25 @@ impl DownloadManifest {
         hasher.update(&data);
 
         // Magic
-        result.append(1153351692u32.to_le_bytes().to_vec().borrow_mut());
+        let mut result = BinaryWriter::new();
+        result.write_u32(1153351692u32);
         // Header Size
-        result.append(41u32.to_le_bytes().to_vec().borrow_mut());
+        result.write_u32(41u32);
         // Size uncompressed
-        result.append((data.len() as u32).to_le_bytes().to_vec().borrow_mut());
+        result.write_u32(data.len() as u32);
         // Size compressed
         let mut z = ZlibEncoder::new(Vec::new(), Compression::default());
         std::io::Write::write_all(&mut z, &data).unwrap();
-        let mut compressed = z.finish().unwrap();
-        result.append(
-            (compressed.len() as u32)
-                .to_le_bytes()
-                .to_vec()
-                .borrow_mut(),
-        );
+        let compressed = z.finish().unwrap();
+        result.write_u32(compressed.len() as u32);
         // Sha Hash
-        result.append(hasher.finalize().to_vec().borrow_mut());
+        result.write_bytes(&hasher.finalize());
         // Stored as (Compressed)
-        result.push(1);
+        result.write_u8(1);
         // Version
-        result.append(18u32.to_le_bytes().to_vec().borrow_mut());
-        result.append(compressed.borrow_mut());
-        result
+        result.write_u32(18u32);
+        result.write_bytes(&compressed);
+        result.into_vec()
     }
 }
 

--- a/src/api/types/download_manifest.rs
+++ b/src/api/types/download_manifest.rs
@@ -319,7 +319,7 @@ impl DownloadManifest {
         // Reading Header
         let magic = crate::api::utils::read_le(&buffer, &mut position);
         if magic != 1153351692 {
-            error!("No header magic");
+            debug!("No header magic, not a binary manifest");
             return None;
         }
         let mut header_size = crate::api::utils::read_le(&buffer, &mut position);
@@ -327,7 +327,13 @@ impl DownloadManifest {
         let _size_uncompressed = crate::api::utils::read_le(&buffer, &mut position);
         let _size_compressed = crate::api::utils::read_le(&buffer, &mut position);
         position += 20;
-        let sha_hash: [u8; 20] = buffer[position - 20..position].try_into().unwrap();
+        let sha_hash: [u8; 20] = match buffer[position - 20..position].try_into() {
+            Ok(h) => h,
+            Err(_) => {
+                error!("Buffer too short for SHA hash");
+                return None;
+            }
+        };
         let compressed = !matches!(buffer[position], 0);
         position += 1;
         let _version = crate::api::utils::read_le(&buffer, &mut position);
@@ -336,7 +342,10 @@ impl DownloadManifest {
             debug!("Uncompressing");
             let mut z = ZlibDecoder::new(&buffer[position..]);
             let mut data: Vec<u8> = Vec::new();
-            z.read_to_end(&mut data).unwrap();
+            if z.read_to_end(&mut data).is_err() {
+                error!("Failed to decompress manifest data");
+                return None;
+            }
             if !crate::api::utils::do_vecs_match(sha_hash.as_ref(), &Sha1::digest(&data)) {
                 error!("The extracted hash does not match");
                 return None;
@@ -481,10 +490,8 @@ impl DownloadManifest {
                 chunk.guid.clone(),
                 u128::try_from(chunk.file_size).unwrap_or_default(),
             );
-            res.data_group_list.insert(
-                chunk.guid,
-                chunk.group_num.into(),
-            );
+            res.data_group_list
+                .insert(chunk.guid, chunk.group_num.into());
         }
         res.chunk_sha_list = Some(chunk_sha_list);
 
@@ -787,7 +794,12 @@ impl DownloadManifest {
             }
         }
 
-        for sha in self.chunk_sha_list.as_ref().unwrap().values() {
+        for sha in self
+            .chunk_sha_list
+            .as_ref()
+            .unwrap_or(&HashMap::new())
+            .values()
+        {
             match crate::api::utils::decode_hex(sha.as_str()) {
                 Ok(mut s) => chunks.append(s.borrow_mut()),
                 Err(_) => chunks.append(vec![0u8; 20].borrow_mut()),
@@ -869,7 +881,9 @@ impl DownloadManifest {
 
         // flags
         // TODO: Figure out what Epic puts in theirs
-        files.resize(self.file_manifest_list.len(), 0);
+        for _ in &self.file_manifest_list {
+            files.push(0u8);
+        }
 
         // install tags
         // TODO: Figure out what Epic puts in theirs
@@ -1056,4 +1070,173 @@ struct BinaryChunkInfo {
     group_num: u8,
     window_size: u32,
     file_size: i64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn chunk_dir_versions() {
+        assert_eq!(DownloadManifest::chunk_dir(0), "Chunks");
+        assert_eq!(DownloadManifest::chunk_dir(3), "ChunksV2");
+        assert_eq!(DownloadManifest::chunk_dir(6), "ChunksV3");
+        assert_eq!(DownloadManifest::chunk_dir(15), "ChunksV4");
+        assert_eq!(DownloadManifest::chunk_dir(20), "ChunksV4");
+    }
+
+    #[test]
+    fn custom_field_get_set() {
+        let mut manifest = DownloadManifest::default();
+        assert_eq!(manifest.custom_field("foo"), None);
+        manifest.set_custom_field("foo".to_string(), "bar".to_string());
+        assert_eq!(manifest.custom_field("foo"), Some("bar".to_string()));
+
+        let mut populated = DownloadManifest {
+            custom_fields: Some(HashMap::from([("alpha".to_string(), "beta".to_string())])),
+            ..DownloadManifest::default()
+        };
+        populated.set_custom_field("gamma".to_string(), "delta".to_string());
+        assert_eq!(populated.custom_field("alpha"), Some("beta".to_string()));
+        assert_eq!(populated.custom_field("gamma"), Some("delta".to_string()));
+    }
+
+    #[test]
+    fn total_download_size_empty() {
+        let manifest = DownloadManifest::default();
+        assert_eq!(manifest.total_download_size(), 0);
+    }
+
+    #[test]
+    fn total_download_size_with_data() {
+        let manifest = DownloadManifest {
+            chunk_filesize_list: HashMap::from([
+                ("a".to_string(), 100u128),
+                ("b".to_string(), 200u128),
+                ("c".to_string(), 300u128),
+            ]),
+            ..DownloadManifest::default()
+        };
+        assert_eq!(manifest.total_download_size(), 600);
+    }
+
+    #[test]
+    fn total_size_from_file_parts() {
+        let manifest = DownloadManifest {
+            file_manifest_list: vec![FileManifestList {
+                filename: "one.dat".to_string(),
+                file_hash: "0000000000000000000000000000000000000000".to_string(),
+                file_chunk_parts: vec![
+                    FileChunkPart {
+                        guid: "guid1".to_string(),
+                        link: None,
+                        offset: 0,
+                        size: 10,
+                    },
+                    FileChunkPart {
+                        guid: "guid2".to_string(),
+                        link: None,
+                        offset: 10,
+                        size: 20,
+                    },
+                ],
+            }],
+            ..DownloadManifest::default()
+        };
+        assert_eq!(manifest.total_size(), 30);
+    }
+
+    #[test]
+    fn file_manifest_list_size() {
+        let file = FileManifestList {
+            filename: "test.dat".to_string(),
+            file_hash: "0000000000000000000000000000000000000000".to_string(),
+            file_chunk_parts: vec![
+                FileChunkPart {
+                    guid: "a".to_string(),
+                    link: None,
+                    offset: 0,
+                    size: 100,
+                },
+                FileChunkPart {
+                    guid: "b".to_string(),
+                    link: None,
+                    offset: 100,
+                    size: 200,
+                },
+                FileChunkPart {
+                    guid: "c".to_string(),
+                    link: None,
+                    offset: 300,
+                    size: 300,
+                },
+            ],
+        };
+        assert_eq!(file.size(), 600);
+    }
+
+    #[test]
+    fn binary_roundtrip() {
+        let guid = "00000001000000020000000300000004".to_string();
+        let file_hash = "0000000000000000000000000000000000000000".to_string();
+        let manifest = DownloadManifest {
+            manifest_file_version: 18,
+            app_name_string: "TestApp".to_string(),
+            build_version_string: "1.0.0".to_string(),
+            file_manifest_list: vec![FileManifestList {
+                filename: "test.dat".to_string(),
+                file_hash: file_hash.clone(),
+                file_chunk_parts: vec![FileChunkPart {
+                    guid: guid.clone(),
+                    link: None,
+                    offset: 0,
+                    size: 65536,
+                }],
+            }],
+            chunk_hash_list: HashMap::from([(guid.clone(), 12345u128)]),
+            chunk_sha_list: Some(HashMap::from([(
+                guid.clone(),
+                "0000000000000000000000000000000000000000".to_string(),
+            )])),
+            data_group_list: HashMap::from([(guid.clone(), 1u128)]),
+            chunk_filesize_list: HashMap::from([(guid.clone(), 65536u128)]),
+            custom_fields: Some(HashMap::new()),
+            ..DownloadManifest::default()
+        };
+
+        let roundtrip = DownloadManifest::from_vec(manifest.to_vec()).unwrap();
+        assert_eq!(roundtrip.app_name_string, "TestApp");
+        assert_eq!(roundtrip.build_version_string, "1.0.0");
+        assert_eq!(roundtrip.manifest_file_version, 18);
+        assert_eq!(roundtrip.chunk_hash_list.len(), 1);
+        assert_eq!(roundtrip.file_manifest_list.len(), 1);
+        assert_eq!(roundtrip.file_manifest_list[0].filename, "test.dat");
+    }
+
+    #[test]
+    fn parse_invalid_data() {
+        assert_eq!(DownloadManifest::parse(vec![0, 1, 2, 3]), None);
+    }
+
+    #[test]
+    fn parse_invalid_json() {
+        assert_eq!(DownloadManifest::parse(b"not json".to_vec()), None);
+    }
+
+    #[test]
+    fn from_vec_no_magic() {
+        assert_eq!(
+            DownloadManifest::from_vec(vec![0, 0, 0, 0, 0, 0, 0, 0]),
+            None
+        );
+    }
+
+    #[test]
+    fn from_vec_too_short() {
+        assert_eq!(
+            DownloadManifest::from_vec(vec![0x4C, 0xB4, 0xCB, 0x44]),
+            None
+        );
+    }
 }

--- a/src/api/types/download_manifest.rs
+++ b/src/api/types/download_manifest.rs
@@ -478,11 +478,16 @@ impl DownloadManifest {
         }
     }
 
-    pub(crate) fn set_custom_field(&mut self, key: String, value: String) {
+    pub(crate) fn set_custom_field(&mut self, key: &str, value: &str) {
         if let Some(fields) = self.custom_fields.as_mut() {
-            fields.insert(key, value);
+            fields.insert(key.to_string(), value.to_string());
         } else {
-            self.custom_fields = Some([(key, value)].iter().cloned().collect())
+            self.custom_fields = Some(
+                [(key.to_string(), value.to_string())]
+                    .iter()
+                    .cloned()
+                    .collect(),
+            )
         };
     }
 
@@ -517,8 +522,8 @@ impl DownloadManifest {
         let chunk_dir = DownloadManifest::chunk_dir(self.manifest_file_version);
         let mut result: HashMap<String, Url> = HashMap::new();
 
-        for (guid, hash) in self.chunk_hash_list.clone() {
-            let group_num = match self.data_group_list.get(&guid) {
+        for (guid, hash) in &self.chunk_hash_list {
+            let group_num = match self.data_group_list.get(guid.as_str()) {
                 None => {
                     continue;
                 }
@@ -530,8 +535,8 @@ impl DownloadManifest {
                     "{}/{}/{:02}/{:016X}_{}.chunk",
                     url,
                     chunk_dir,
-                    group_num,
-                    hash,
+                    *group_num,
+                    *hash,
                     guid.to_uppercase()
                 ))
                 .unwrap(),
@@ -545,23 +550,24 @@ impl DownloadManifest {
         let mut result: HashMap<String, FileManifestList> = HashMap::new();
         let links = self.download_links().unwrap_or_default();
 
-        for file in self.file_manifest_list.clone() {
+        for file in &self.file_manifest_list {
             result.insert(
                 file.filename.clone(),
                 FileManifestList {
-                    filename: file.filename,
-                    file_hash: file.file_hash,
+                    filename: file.filename.clone(),
+                    file_hash: file.file_hash.clone(),
                     file_chunk_parts: {
                         let mut temp: Vec<FileChunkPart> = Vec::new();
-                        for part in file.file_chunk_parts {
+                        for part in &file.file_chunk_parts {
+                            let link = match links.get(&part.guid) {
+                                None => {
+                                    continue;
+                                }
+                                Some(u) => Some(u.clone()),
+                            };
                             temp.push(FileChunkPart {
                                 guid: part.guid.clone(),
-                                link: match links.get(&part.guid) {
-                                    None => {
-                                        continue;
-                                    }
-                                    Some(u) => Some(u.clone()),
-                                },
+                                link,
                                 offset: part.offset,
                                 size: part.size,
                             })
@@ -597,15 +603,13 @@ impl DownloadManifest {
         debug!("Attempting to parse download manifest from binary data");
         // debug!("attempted json {:?}", serde_json::from_slice::<DownloadManifest>(data.as_slice()));
         let hash = Sha1::digest(&data);
-        match DownloadManifest::from_vec(data.clone()) {
+        match DownloadManifest::from_vec(&data) {
             None => {
                 debug!("Not binary manifest trying json");
                 match serde_json::from_slice::<DownloadManifest>(data.as_slice()) {
                     Ok(mut dm) => {
-                        dm.set_custom_field(
-                            "DownloadedManifestHash".to_string(),
-                            format!("{:x}", hash),
-                        );
+                        let hash_string = format!("{:x}", hash);
+                        dm.set_custom_field("DownloadedManifestHash", &hash_string);
                         Some(dm)
                     }
                     Err(_) => None,
@@ -613,14 +617,15 @@ impl DownloadManifest {
             }
             Some(mut dm) => {
                 debug!("Binary parsing successful");
-                dm.set_custom_field("DownloadedManifestHash".to_string(), format!("{:x}", hash));
+                let hash_string = format!("{:x}", hash);
+                dm.set_custom_field("DownloadedManifestHash", &hash_string);
                 Some(dm)
             }
         }
     }
 
     /// Creates the structure from binary data
-    pub fn from_vec(buffer: Vec<u8>) -> Option<DownloadManifest> {
+    pub fn from_vec(buffer: &[u8]) -> Option<DownloadManifest> {
         let mut res = DownloadManifest {
             manifest_file_version: 0,
             b_is_file_data: false,
@@ -644,7 +649,7 @@ impl DownloadManifest {
         };
 
         // Reading Header
-        let (buffer, mut position, header_size) = parse_header(&buffer)?;
+        let (buffer, mut position, header_size) = parse_header(buffer)?;
 
         // Manifest Meta
         let meta_size = parse_meta(&buffer, &mut position, &mut res);
@@ -722,15 +727,13 @@ impl DownloadManifest {
             Err(_) => meta.append(0u32.to_le_bytes().to_vec().borrow_mut()),
         }
 
-        meta.append(crate::api::utils::write_fstring(self.app_name_string.clone()).borrow_mut());
+        meta.append(crate::api::utils::write_fstring(&self.app_name_string).borrow_mut());
 
-        meta.append(
-            crate::api::utils::write_fstring(self.build_version_string.clone()).borrow_mut(),
-        );
+        meta.append(crate::api::utils::write_fstring(&self.build_version_string).borrow_mut());
 
-        meta.append(crate::api::utils::write_fstring(self.launch_exe_string.clone()).borrow_mut());
+        meta.append(crate::api::utils::write_fstring(&self.launch_exe_string).borrow_mut());
 
-        meta.append(crate::api::utils::write_fstring(self.launch_command.clone()).borrow_mut());
+        meta.append(crate::api::utils::write_fstring(&self.launch_command).borrow_mut());
 
         match &self.prereq_ids {
             None => meta.append(0u32.to_le_bytes().to_vec().borrow_mut()),
@@ -742,21 +745,19 @@ impl DownloadManifest {
                         .borrow_mut(),
                 );
                 for prereq_id in prereq_ids {
-                    meta.append(crate::api::utils::write_fstring(prereq_id.clone()).borrow_mut());
+                    meta.append(crate::api::utils::write_fstring(prereq_id).borrow_mut());
                 }
             }
         }
 
-        meta.append(crate::api::utils::write_fstring(self.prereq_name.clone()).borrow_mut());
+        meta.append(crate::api::utils::write_fstring(&self.prereq_name).borrow_mut());
 
-        meta.append(crate::api::utils::write_fstring(self.prereq_path.clone()).borrow_mut());
+        meta.append(crate::api::utils::write_fstring(&self.prereq_path).borrow_mut());
 
-        meta.append(crate::api::utils::write_fstring(self.prereq_args.clone()).borrow_mut());
+        meta.append(crate::api::utils::write_fstring(&self.prereq_args).borrow_mut());
 
         if !self.build_version_string.is_empty() {
-            meta.append(
-                crate::api::utils::write_fstring(self.build_version_string.clone()).borrow_mut(),
-            );
+            meta.append(crate::api::utils::write_fstring(&self.build_version_string).borrow_mut());
         }
         // Meta Size
         data.append(
@@ -879,13 +880,13 @@ impl DownloadManifest {
 
         // Filenames
         for file in &self.file_manifest_list {
-            files.append(crate::api::utils::write_fstring(file.filename.clone()).borrow_mut());
+            files.append(crate::api::utils::write_fstring(&file.filename).borrow_mut());
         }
 
         // Symlink target
         // TODO: Figure out what Epic puts in theirs
         for _ in &self.file_manifest_list {
-            files.append(crate::api::utils::write_fstring("".to_string()).borrow_mut());
+            files.append(crate::api::utils::write_fstring("").borrow_mut());
         }
 
         // hash
@@ -976,10 +977,10 @@ impl DownloadManifest {
                 );
 
                 for key in custom_fields.keys() {
-                    custom.append(crate::api::utils::write_fstring(key.to_string()).borrow_mut());
+                    custom.append(crate::api::utils::write_fstring(key).borrow_mut());
                 }
                 for value in custom_fields.values() {
-                    custom.append(crate::api::utils::write_fstring(value.to_string()).borrow_mut());
+                    custom.append(crate::api::utils::write_fstring(value).borrow_mut());
                 }
             }
         }
@@ -1122,14 +1123,14 @@ mod tests {
     fn custom_field_get_set() {
         let mut manifest = DownloadManifest::default();
         assert_eq!(manifest.custom_field("foo"), None);
-        manifest.set_custom_field("foo".to_string(), "bar".to_string());
+        manifest.set_custom_field("foo", "bar");
         assert_eq!(manifest.custom_field("foo"), Some("bar".to_string()));
 
         let mut populated = DownloadManifest {
             custom_fields: Some(HashMap::from([("alpha".to_string(), "beta".to_string())])),
             ..DownloadManifest::default()
         };
-        populated.set_custom_field("gamma".to_string(), "delta".to_string());
+        populated.set_custom_field("gamma", "delta");
         assert_eq!(populated.custom_field("alpha"), Some("beta".to_string()));
         assert_eq!(populated.custom_field("gamma"), Some("delta".to_string()));
     }
@@ -1237,7 +1238,8 @@ mod tests {
             ..DownloadManifest::default()
         };
 
-        let roundtrip = DownloadManifest::from_vec(manifest.to_vec()).unwrap();
+        let manifest_vec = manifest.to_vec();
+        let roundtrip = DownloadManifest::from_vec(&manifest_vec).unwrap();
         assert_eq!(roundtrip.app_name_string, "TestApp");
         assert_eq!(roundtrip.build_version_string, "1.0.0");
         assert_eq!(roundtrip.manifest_file_version, 18);
@@ -1258,17 +1260,13 @@ mod tests {
 
     #[test]
     fn from_vec_no_magic() {
-        assert_eq!(
-            DownloadManifest::from_vec(vec![0, 0, 0, 0, 0, 0, 0, 0]),
-            None
-        );
+        let buffer = vec![0, 0, 0, 0, 0, 0, 0, 0];
+        assert_eq!(DownloadManifest::from_vec(&buffer), None);
     }
 
     #[test]
     fn from_vec_too_short() {
-        assert_eq!(
-            DownloadManifest::from_vec(vec![0x4C, 0xB4, 0xCB, 0x44]),
-            None
-        );
+        let buffer = vec![0x4C, 0xB4, 0xCB, 0x44];
+        assert_eq!(DownloadManifest::from_vec(&buffer), None);
     }
 }

--- a/src/api/types/download_manifest.rs
+++ b/src/api/types/download_manifest.rs
@@ -135,6 +135,335 @@ where
     Ok(data)
 }
 
+fn parse_header(buffer: &[u8]) -> Option<(Vec<u8>, usize, u32)> {
+    let mut position: usize = 0;
+
+    let magic = crate::api::utils::read_le(buffer, &mut position);
+    if magic != 1153351692 {
+        debug!("No header magic, not a binary manifest");
+        return None;
+    }
+    let mut header_size = crate::api::utils::read_le(buffer, &mut position);
+    debug!("Header size: {}", header_size);
+    let _size_uncompressed = crate::api::utils::read_le(buffer, &mut position);
+    let _size_compressed = crate::api::utils::read_le(buffer, &mut position);
+    position += 20;
+    let sha_hash: [u8; 20] = match buffer[position - 20..position].try_into() {
+        Ok(h) => h,
+        Err(_) => {
+            error!("Buffer too short for SHA hash");
+            return None;
+        }
+    };
+    let compressed = !matches!(buffer[position], 0);
+    position += 1;
+    let _version = crate::api::utils::read_le(buffer, &mut position);
+
+    let mut position_after_header = position;
+    let data = if compressed {
+        debug!("Uncompressing");
+        let mut z = ZlibDecoder::new(&buffer[position..]);
+        let mut data: Vec<u8> = Vec::new();
+        if z.read_to_end(&mut data).is_err() {
+            error!("Failed to decompress manifest data");
+            return None;
+        }
+        if !crate::api::utils::do_vecs_match(sha_hash.as_ref(), &Sha1::digest(&data)) {
+            error!("The extracted hash does not match");
+            return None;
+        }
+        position_after_header = 0;
+        header_size = 0;
+        data
+    } else {
+        buffer.to_vec()
+    };
+
+    debug!(
+        "Download manifest header read length(needs to match {}): {}",
+        header_size, position_after_header
+    );
+
+    Some((data, position_after_header, header_size))
+}
+
+fn parse_meta(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
+    let meta_size = crate::api::utils::read_le(buffer, position);
+
+    let data_version = buffer[*position];
+    *position += 1;
+
+    res.manifest_file_version = crate::api::utils::read_le(buffer, position).into();
+
+    res.b_is_file_data = !matches!(buffer[*position], 0);
+    *position += 1;
+    res.app_id = crate::api::utils::read_le(buffer, position) as u128;
+    res.app_name_string = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    res.build_version_string =
+        crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    res.launch_exe_string = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    res.launch_command = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+
+    let entries = crate::api::utils::read_le(buffer, position);
+    let mut prereq_ids: Vec<String> = Vec::new();
+    for _ in 0..entries {
+        if let Some(s) = crate::api::utils::read_fstring(buffer, position) {
+            prereq_ids.push(s)
+        }
+    }
+    if prereq_ids.is_empty() {
+        res.prereq_ids = None
+    } else {
+        res.prereq_ids = Some(prereq_ids);
+    }
+
+    res.prereq_name = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    res.prereq_path = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    res.prereq_args = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+
+    if data_version >= 1 {
+        res.build_version_string =
+            crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    }
+    if data_version >= 2 {
+        res.uninstall_action_path =
+            Some(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
+        res.uninstall_action_args =
+            Some(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
+    }
+
+    debug!("Manifest end position {}", position);
+
+    meta_size
+}
+
+fn parse_chunks(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
+    let chunk_size = crate::api::utils::read_le(buffer, position);
+    debug!("Chunk size {}", chunk_size);
+
+    let _version = buffer[*position];
+    debug!("version: {}", _version);
+    *position += 1;
+
+    debug!("Chunk count at position: {}", position);
+    let count = crate::api::utils::read_le(buffer, position);
+    debug!("Reading {} chunks", count);
+
+    let mut chunks: Vec<BinaryChunkInfo> = Vec::new();
+    for _i in 0..count {
+        chunks.push(BinaryChunkInfo {
+            manifest_version: res.manifest_file_version,
+            guid: format!(
+                "{:08x}{:08x}{:08x}{:08x}",
+                crate::api::utils::read_le(buffer, position),
+                crate::api::utils::read_le(buffer, position),
+                crate::api::utils::read_le(buffer, position),
+                crate::api::utils::read_le(buffer, position)
+            ),
+            hash: 0,
+            sha_hash: Vec::new(),
+            group_num: 0,
+            window_size: 0,
+            file_size: 0,
+        });
+    }
+
+    debug!("Reading Chunk Hashes");
+    for chunk in chunks.iter_mut() {
+        chunk.hash = crate::api::utils::read_le_64(buffer, position) as u128;
+    }
+    debug!("Reading Chunk Sha Hashes");
+    for chunk in chunks.iter_mut() {
+        *position += 20;
+        chunk.sha_hash = buffer[*position - 20..*position].into();
+    }
+
+    debug!("Reading Chunk group nums");
+    for chunk in chunks.iter_mut() {
+        chunk.group_num = buffer[*position];
+        *position += 1;
+    }
+    for chunk in chunks.iter_mut() {
+        chunk.window_size = crate::api::utils::read_le(buffer, position);
+    }
+    for chunk in chunks.iter_mut() {
+        chunk.file_size = crate::api::utils::read_le_64_signed(buffer, position);
+    }
+
+    let mut chunk_sha_list: HashMap<String, String> = HashMap::new();
+    for chunk in chunks {
+        chunk_sha_list.insert(
+            chunk.guid.clone(),
+            chunk.sha_hash.iter().fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{b:02x}");
+                output
+            }),
+        );
+        res.chunk_hash_list.insert(chunk.guid.clone(), chunk.hash);
+        res.chunk_filesize_list.insert(
+            chunk.guid.clone(),
+            u128::try_from(chunk.file_size).unwrap_or_default(),
+        );
+        res.data_group_list
+            .insert(chunk.guid, chunk.group_num.into());
+    }
+    res.chunk_sha_list = Some(chunk_sha_list);
+
+    chunk_size
+}
+
+fn parse_files(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
+    let filemanifest_size = crate::api::utils::read_le(buffer, position);
+
+    let fm_version = buffer[*position];
+    debug!("File manifest version: {}", fm_version);
+    *position += 1;
+    let count = crate::api::utils::read_le(buffer, position);
+
+    let mut files: Vec<BinaryFileManifest> = Vec::new();
+    for _ in 0..count {
+        files.push(BinaryFileManifest {
+            filename: crate::api::utils::read_fstring(buffer, position).unwrap_or_default(),
+            symlink_target: "".to_string(),
+            hash: vec![],
+            hash_md5: vec![],
+            hash_sha256: vec![],
+            mime_type: "".to_string(),
+            flags: 0,
+            install_tags: vec![],
+            chunk_parts: vec![],
+            file_size: 0,
+        });
+    }
+
+    for file in files.iter_mut() {
+        file.symlink_target = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+    }
+
+    for file in files.iter_mut() {
+        *position += 20;
+        file.hash = buffer[*position - 20..*position].into();
+    }
+
+    for file in files.iter_mut() {
+        file.flags = buffer[*position];
+        *position += 1;
+    }
+
+    for file in files.iter_mut() {
+        let elem_count = crate::api::utils::read_le(buffer, position);
+        for _ in 0..elem_count {
+            file.install_tags
+                .push(crate::api::utils::read_fstring(buffer, position).unwrap_or_default())
+        }
+    }
+
+    // File Chunks
+    for i in 0..count {
+        if let Some(file) = files.get_mut(i as usize) {
+            let elem_count = crate::api::utils::read_le(buffer, position);
+            let mut offset: u128 = 0;
+            for _i in 0..elem_count {
+                let total = *position;
+                let chunk_size = crate::api::utils::read_le(buffer, position);
+                let chunk = BinaryChunkPart {
+                    guid: format!(
+                        "{:08x}{:08x}{:08x}{:08x}",
+                        crate::api::utils::read_le(buffer, position),
+                        crate::api::utils::read_le(buffer, position),
+                        crate::api::utils::read_le(buffer, position),
+                        crate::api::utils::read_le(buffer, position)
+                    ),
+                    offset: crate::api::utils::read_le(buffer, position) as u128,
+                    size: crate::api::utils::read_le(buffer, position) as u128,
+                    file_offset: offset,
+                };
+                offset += chunk.size;
+                let diff = *position - total - chunk_size as usize;
+                if diff > 0 {
+                    warn!("Did not read the entire chunk part!");
+                    *position += diff
+                }
+                file.chunk_parts.push(chunk);
+            }
+        }
+    }
+
+    if fm_version >= 1 {
+        for file in files.iter_mut() {
+            let has_md5 = crate::api::utils::read_le(buffer, position);
+            if has_md5 != 0 {
+                *position += 16;
+                file.hash_md5 = buffer[*position - 16..*position].into();
+            }
+        }
+        for file in files.iter_mut() {
+            file.mime_type = crate::api::utils::read_fstring(buffer, position).unwrap_or_default();
+        }
+    }
+
+    if fm_version >= 2 {
+        for file in files.iter_mut() {
+            *position += 32;
+            file.hash_sha256 = buffer[*position - 32..*position].into();
+        }
+    }
+
+    for file in files.iter_mut() {
+        file.file_size = file.chunk_parts.iter().map(|chunk| chunk.size).sum();
+    }
+
+    for file in files.iter_mut() {
+        let mut chunks: Vec<FileChunkPart> = Vec::new();
+        for chunk in &file.chunk_parts {
+            chunks.push(FileChunkPart {
+                guid: chunk.guid.clone(),
+                link: None,
+                offset: chunk.offset,
+                size: chunk.size,
+            })
+        }
+        res.file_manifest_list.push(FileManifestList {
+            filename: file.filename.clone(),
+            file_hash: file.hash.iter().fold(String::new(), |mut output, b| {
+                let _ = write!(output, "{b:02x}");
+                output
+            }),
+            file_chunk_parts: chunks,
+        })
+    }
+
+    filemanifest_size
+}
+
+fn parse_custom_fields(buffer: &[u8], position: &mut usize, res: &mut DownloadManifest) -> u32 {
+    let size = crate::api::utils::read_le(buffer, position);
+
+    let _version = buffer[*position];
+    *position += 1;
+    let count = crate::api::utils::read_le(buffer, position);
+
+    let mut keys: Vec<String> = Vec::new();
+    let mut values: Vec<String> = Vec::new();
+
+    for _ in 0..count {
+        keys.push(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
+    }
+
+    for _ in 0..count {
+        values.push(crate::api::utils::read_fstring(buffer, position).unwrap_or_default());
+    }
+
+    let mut custom_fields: HashMap<String, String> = HashMap::new();
+    for i in 0..count {
+        custom_fields.insert(keys[i as usize].clone(), values[i as usize].clone());
+    }
+
+    res.custom_fields = Some(custom_fields);
+
+    size
+}
+
 impl DownloadManifest {
     /// Get chunk dir based on the manifest version
     fn chunk_dir(version: u128) -> &'static str {
@@ -291,7 +620,7 @@ impl DownloadManifest {
     }
 
     /// Creates the structure from binary data
-    pub fn from_vec(mut buffer: Vec<u8>) -> Option<DownloadManifest> {
+    pub fn from_vec(buffer: Vec<u8>) -> Option<DownloadManifest> {
         let mut res = DownloadManifest {
             manifest_file_version: 0,
             b_is_file_data: false,
@@ -314,107 +643,11 @@ impl DownloadManifest {
             custom_fields: Default::default(),
         };
 
-        let mut position: usize = 0;
-
         // Reading Header
-        let magic = crate::api::utils::read_le(&buffer, &mut position);
-        if magic != 1153351692 {
-            debug!("No header magic, not a binary manifest");
-            return None;
-        }
-        let mut header_size = crate::api::utils::read_le(&buffer, &mut position);
-        debug!("Header size: {}", header_size);
-        let _size_uncompressed = crate::api::utils::read_le(&buffer, &mut position);
-        let _size_compressed = crate::api::utils::read_le(&buffer, &mut position);
-        position += 20;
-        let sha_hash: [u8; 20] = match buffer[position - 20..position].try_into() {
-            Ok(h) => h,
-            Err(_) => {
-                error!("Buffer too short for SHA hash");
-                return None;
-            }
-        };
-        let compressed = !matches!(buffer[position], 0);
-        position += 1;
-        let _version = crate::api::utils::read_le(&buffer, &mut position);
-
-        buffer = if compressed {
-            debug!("Uncompressing");
-            let mut z = ZlibDecoder::new(&buffer[position..]);
-            let mut data: Vec<u8> = Vec::new();
-            if z.read_to_end(&mut data).is_err() {
-                error!("Failed to decompress manifest data");
-                return None;
-            }
-            if !crate::api::utils::do_vecs_match(sha_hash.as_ref(), &Sha1::digest(&data)) {
-                error!("The extracted hash does not match");
-                return None;
-            }
-            position = 0;
-            header_size = 0;
-            data
-        } else {
-            buffer
-        };
-
-        debug!(
-            "Download manifest header read length(needs to match {}): {}",
-            header_size, position
-        );
+        let (buffer, mut position, header_size) = parse_header(&buffer)?;
 
         // Manifest Meta
-
-        let meta_size = crate::api::utils::read_le(&buffer, &mut position);
-
-        let data_version = buffer[position];
-        position += 1;
-
-        res.manifest_file_version = crate::api::utils::read_le(&buffer, &mut position).into();
-
-        res.b_is_file_data = !matches!(buffer[position], 0);
-        position += 1;
-        res.app_id = crate::api::utils::read_le(&buffer, &mut position) as u128;
-        res.app_name_string =
-            crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-        res.build_version_string =
-            crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-        res.launch_exe_string =
-            crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-        res.launch_command =
-            crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-
-        let entries = crate::api::utils::read_le(&buffer, &mut position);
-        let mut prereq_ids: Vec<String> = Vec::new();
-        for _ in 0..entries {
-            if let Some(s) = crate::api::utils::read_fstring(&buffer, &mut position) {
-                prereq_ids.push(s)
-            }
-        }
-        if prereq_ids.is_empty() {
-            res.prereq_ids = None
-        } else {
-            res.prereq_ids = Some(prereq_ids);
-        }
-
-        res.prereq_name =
-            crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-        res.prereq_path =
-            crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-        res.prereq_args =
-            crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-
-        if data_version >= 1 {
-            res.build_version_string =
-                crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-        }
-        if data_version >= 2 {
-            res.uninstall_action_path =
-                Some(crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default());
-            res.uninstall_action_args =
-                Some(crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default());
-        }
-
-        debug!("Manifest end position {}", position);
+        let meta_size = parse_meta(&buffer, &mut position, &mut res);
 
         debug!(
             "Manifest metadata read length(needs to match {}): {}",
@@ -423,77 +656,7 @@ impl DownloadManifest {
         );
 
         // Chunks
-
-        let chunk_size = crate::api::utils::read_le(&buffer, &mut position);
-        debug!("Chunk size {}", chunk_size);
-
-        let _version = buffer[position];
-        debug!("version: {}", _version);
-        position += 1;
-
-        debug!("Chunk count at position: {}", position);
-        let count = crate::api::utils::read_le(&buffer, &mut position);
-        debug!("Reading {} chunks", count);
-
-        let mut chunks: Vec<BinaryChunkInfo> = Vec::new();
-        for _i in 0..count {
-            chunks.push(BinaryChunkInfo {
-                manifest_version: res.manifest_file_version,
-                guid: format!(
-                    "{:08x}{:08x}{:08x}{:08x}",
-                    crate::api::utils::read_le(&buffer, &mut position),
-                    crate::api::utils::read_le(&buffer, &mut position),
-                    crate::api::utils::read_le(&buffer, &mut position),
-                    crate::api::utils::read_le(&buffer, &mut position)
-                ),
-                hash: 0,
-                sha_hash: Vec::new(),
-                group_num: 0,
-                window_size: 0,
-                file_size: 0,
-            });
-        }
-
-        debug!("Reading Chunk Hashes");
-        for chunk in chunks.iter_mut() {
-            chunk.hash = crate::api::utils::read_le_64(&buffer, &mut position) as u128;
-        }
-        debug!("Reading Chunk Sha Hashes");
-        for chunk in chunks.iter_mut() {
-            position += 20;
-            chunk.sha_hash = buffer[position - 20..position].into();
-        }
-
-        debug!("Reading Chunk group nums");
-        for chunk in chunks.iter_mut() {
-            chunk.group_num = buffer[position];
-            position += 1;
-        }
-        for chunk in chunks.iter_mut() {
-            chunk.window_size = crate::api::utils::read_le(&buffer, &mut position);
-        }
-        for chunk in chunks.iter_mut() {
-            chunk.file_size = crate::api::utils::read_le_64_signed(&buffer, &mut position);
-        }
-
-        let mut chunk_sha_list: HashMap<String, String> = HashMap::new();
-        for chunk in chunks {
-            chunk_sha_list.insert(
-                chunk.guid.clone(),
-                chunk.sha_hash.iter().fold(String::new(), |mut output, b| {
-                    let _ = write!(output, "{b:02x}");
-                    output
-                }),
-            );
-            res.chunk_hash_list.insert(chunk.guid.clone(), chunk.hash);
-            res.chunk_filesize_list.insert(
-                chunk.guid.clone(),
-                u128::try_from(chunk.file_size).unwrap_or_default(),
-            );
-            res.data_group_list
-                .insert(chunk.guid, chunk.group_num.into());
-        }
-        res.chunk_sha_list = Some(chunk_sha_list);
+        let chunk_size = parse_chunks(&buffer, &mut position, &mut res);
 
         debug!(
             "Chunks read length(needs to match {}): {}",
@@ -502,130 +665,7 @@ impl DownloadManifest {
         );
 
         // File Manifest
-
-        let filemanifest_size = crate::api::utils::read_le(&buffer, &mut position);
-
-        let fm_version = buffer[position];
-        debug!("File manifest version: {}", fm_version);
-        position += 1;
-        let count = crate::api::utils::read_le(&buffer, &mut position);
-
-        let mut files: Vec<BinaryFileManifest> = Vec::new();
-        for _ in 0..count {
-            files.push(BinaryFileManifest {
-                filename: crate::api::utils::read_fstring(&buffer, &mut position)
-                    .unwrap_or_default(),
-                symlink_target: "".to_string(),
-                hash: vec![],
-                hash_md5: vec![],
-                hash_sha256: vec![],
-                mime_type: "".to_string(),
-                flags: 0,
-                install_tags: vec![],
-                chunk_parts: vec![],
-                file_size: 0,
-            });
-        }
-
-        for file in files.iter_mut() {
-            file.symlink_target =
-                crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-        }
-
-        for file in files.iter_mut() {
-            position += 20;
-            file.hash = buffer[position - 20..position].into();
-        }
-
-        for file in files.iter_mut() {
-            file.flags = buffer[position];
-            position += 1;
-        }
-
-        for file in files.iter_mut() {
-            let elem_count = crate::api::utils::read_le(&buffer, &mut position);
-            for _ in 0..elem_count {
-                file.install_tags.push(
-                    crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default(),
-                )
-            }
-        }
-
-        // File Chunks
-        for i in 0..count {
-            if let Some(file) = files.get_mut(i as usize) {
-                let elem_count = crate::api::utils::read_le(&buffer, &mut position);
-                let mut offset: u128 = 0;
-                for _i in 0..elem_count {
-                    let total = position;
-                    let chunk_size = crate::api::utils::read_le(&buffer, &mut position);
-                    let chunk = BinaryChunkPart {
-                        guid: format!(
-                            "{:08x}{:08x}{:08x}{:08x}",
-                            crate::api::utils::read_le(&buffer, &mut position),
-                            crate::api::utils::read_le(&buffer, &mut position),
-                            crate::api::utils::read_le(&buffer, &mut position),
-                            crate::api::utils::read_le(&buffer, &mut position)
-                        ),
-                        offset: crate::api::utils::read_le(&buffer, &mut position) as u128,
-                        size: crate::api::utils::read_le(&buffer, &mut position) as u128,
-                        file_offset: offset,
-                    };
-                    offset += chunk.size;
-                    let diff = position - total - chunk_size as usize;
-                    if diff > 0 {
-                        warn!("Did not read the entire chunk part!");
-                        position += diff
-                    }
-                    file.chunk_parts.push(chunk);
-                }
-            }
-        }
-
-        if fm_version >= 1 {
-            for file in files.iter_mut() {
-                let has_md5 = crate::api::utils::read_le(&buffer, &mut position);
-                if has_md5 != 0 {
-                    position += 16;
-                    file.hash_md5 = buffer[position - 16..position].into();
-                }
-            }
-            for file in files.iter_mut() {
-                file.mime_type =
-                    crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default();
-            }
-        }
-
-        if fm_version >= 2 {
-            for file in files.iter_mut() {
-                position += 32;
-                file.hash_sha256 = buffer[position - 32..position].into();
-            }
-        }
-
-        for file in files.iter_mut() {
-            file.file_size = file.chunk_parts.iter().map(|chunk| chunk.size).sum();
-        }
-
-        for file in files.iter_mut() {
-            let mut chunks: Vec<FileChunkPart> = Vec::new();
-            for chunk in &file.chunk_parts {
-                chunks.push(FileChunkPart {
-                    guid: chunk.guid.clone(),
-                    link: None,
-                    offset: chunk.offset,
-                    size: chunk.size,
-                })
-            }
-            res.file_manifest_list.push(FileManifestList {
-                filename: file.filename.clone(),
-                file_hash: file.hash.iter().fold(String::new(), |mut output, b| {
-                    let _ = write!(output, "{b:02x}");
-                    output
-                }),
-                file_chunk_parts: chunks,
-            })
-        }
+        let filemanifest_size = parse_files(&buffer, &mut position, &mut res);
 
         debug!(
             "File Manifests read length(needs to match {}): {}",
@@ -634,31 +674,7 @@ impl DownloadManifest {
         );
 
         // Custom Fields
-
-        let size = crate::api::utils::read_le(&buffer, &mut position);
-
-        let _version = buffer[position];
-        position += 1;
-        let count = crate::api::utils::read_le(&buffer, &mut position);
-
-        let mut keys: Vec<String> = Vec::new();
-        let mut values: Vec<String> = Vec::new();
-
-        for _ in 0..count {
-            keys.push(crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default());
-        }
-
-        for _ in 0..count {
-            values
-                .push(crate::api::utils::read_fstring(&buffer, &mut position).unwrap_or_default());
-        }
-
-        let mut custom_fields: HashMap<String, String> = HashMap::new();
-        for i in 0..count {
-            custom_fields.insert(keys[i as usize].clone(), values[i as usize].clone());
-        }
-
-        res.custom_fields = Some(custom_fields);
+        let size = parse_custom_fields(&buffer, &mut position, &mut res);
 
         debug!(
             "Custom fields read length(needs to match {}): {}",
@@ -684,10 +700,7 @@ impl DownloadManifest {
         Some(res)
     }
 
-    /// Return a vector containing the manifest data
-    pub fn to_vec(&self) -> Vec<u8> {
-        let mut result: Vec<u8> = Vec::new();
-
+    fn write_meta(&self) -> Vec<u8> {
         let mut data: Vec<u8> = Vec::new();
         let mut meta: Vec<u8> = Vec::new();
         // Data version
@@ -753,9 +766,11 @@ impl DownloadManifest {
                 .borrow_mut(),
         );
         data.append(meta.borrow_mut());
+        data
+    }
 
-        // Chunks
-
+    fn write_chunks(&self) -> Vec<u8> {
+        let mut data: Vec<u8> = Vec::new();
         // version
         let mut chunks: Vec<u8> = vec![0];
 
@@ -846,9 +861,11 @@ impl DownloadManifest {
                 .borrow_mut(),
         );
         data.append(chunks.borrow_mut());
+        data
+    }
 
-        // File Manifest
-
+    fn write_files(&self) -> Vec<u8> {
+        let mut data: Vec<u8> = Vec::new();
         // version
         let mut files: Vec<u8> = vec![0];
 
@@ -937,8 +954,11 @@ impl DownloadManifest {
                 .borrow_mut(),
         );
         data.append(files.borrow_mut());
+        data
+    }
 
-        // Custom Fields
+    fn write_custom_fields(&self) -> Vec<u8> {
+        let mut data: Vec<u8> = Vec::new();
         // version
         let mut custom: Vec<u8> = vec![0];
 
@@ -972,6 +992,18 @@ impl DownloadManifest {
                 .borrow_mut(),
         );
         data.append(custom.borrow_mut());
+        data
+    }
+
+    /// Return a vector containing the manifest data
+    pub fn to_vec(&self) -> Vec<u8> {
+        let mut result: Vec<u8> = Vec::new();
+
+        let mut data: Vec<u8> = Vec::new();
+        data.append(self.write_meta().borrow_mut());
+        data.append(self.write_chunks().borrow_mut());
+        data.append(self.write_files().borrow_mut());
+        data.append(self.write_custom_fields().borrow_mut());
 
         // FINISHING METADATA (Probably done)
 

--- a/src/api/types/download_manifest.rs
+++ b/src/api/types/download_manifest.rs
@@ -136,33 +136,32 @@ where
 }
 
 fn parse_header(buffer: &[u8]) -> Option<(Vec<u8>, usize, u32)> {
-    let mut position: usize = 0;
+    let mut reader = BinaryReader::new(buffer);
 
-    let magic = crate::api::utils::read_le(buffer, &mut position);
+    let magic = reader.read_u32()?;
     if magic != 1153351692 {
         debug!("No header magic, not a binary manifest");
         return None;
     }
-    let mut header_size = crate::api::utils::read_le(buffer, &mut position);
+    let mut header_size = reader.read_u32()?;
     debug!("Header size: {}", header_size);
-    let _size_uncompressed = crate::api::utils::read_le(buffer, &mut position);
-    let _size_compressed = crate::api::utils::read_le(buffer, &mut position);
-    position += 20;
-    let sha_hash: [u8; 20] = match buffer[position - 20..position].try_into() {
+    let _size_uncompressed = reader.read_u32()?;
+    let _size_compressed = reader.read_u32()?;
+    let sha_hash_bytes = reader.read_bytes(20)?;
+    let sha_hash: [u8; 20] = match sha_hash_bytes.try_into() {
         Ok(h) => h,
         Err(_) => {
             error!("Buffer too short for SHA hash");
             return None;
         }
     };
-    let compressed = !matches!(buffer[position], 0);
-    position += 1;
-    let _version = crate::api::utils::read_le(buffer, &mut position);
+    let compressed = !matches!(reader.read_u8()?, 0);
+    let _version = reader.read_u32()?;
 
-    let mut position_after_header = position;
+    let mut position_after_header = reader.position();
     let data = if compressed {
         debug!("Uncompressing");
-        let mut z = ZlibDecoder::new(&buffer[position..]);
+        let mut z = ZlibDecoder::new(&buffer[reader.position()..]);
         let mut data: Vec<u8> = Vec::new();
         if z.read_to_end(&mut data).is_err() {
             error!("Failed to decompress manifest data");
@@ -827,7 +826,6 @@ impl DownloadManifest {
         // TODO: Figure out what Epic puts in theirs
         for _ in &self.file_manifest_list {
             writer.write_u32(0u32);
-            // files.append(crate::api::utils::write_fstring("".to_string()).borrow_mut());
         }
 
         // File Chunks

--- a/src/api/types/entitlement.rs
+++ b/src/api/types/entitlement.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// An entitlement record (game, DLC, or subscription grant).
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/api/types/epic_asset.rs
+++ b/src/api/types/epic_asset.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// A lightweight reference to an owned asset (used to fetch full info and manifests).
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -11,4 +12,3 @@ pub struct EpicAsset {
     pub namespace: String,
     pub asset_id: String,
 }
-

--- a/src/api/types/fab_asset_manifest.rs
+++ b/src/api/types/fab_asset_manifest.rs
@@ -54,3 +54,55 @@ pub struct DistributionPoint {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Metadata {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_download_info(urls: Vec<&str>) -> DownloadInfo {
+        DownloadInfo {
+            artifact_id: "test".to_string(),
+            asset_format: "".to_string(),
+            build_version: "".to_string(),
+            distribution_point_base_urls: vec![],
+            distribution_points: urls
+                .into_iter()
+                .map(|url| DistributionPoint {
+                    manifest_url: url.to_string(),
+                    signature_expiration: time::OffsetDateTime::now_utc(),
+                })
+                .collect(),
+            manifest_hash: "".to_string(),
+            metadata: Metadata {},
+            type_field: "".to_string(),
+        }
+    }
+
+    #[test]
+    fn get_distribution_point_by_base_url_found() {
+        let di = make_download_info(vec![
+            "https://cdn1.example.com/manifest.json",
+            "https://cdn2.example.com/manifest.json",
+        ]);
+        let point = di
+            .get_distribution_point_by_base_url("https://cdn1")
+            .unwrap();
+        assert!(point.manifest_url.starts_with("https://cdn1"));
+    }
+
+    #[test]
+    fn get_distribution_point_by_base_url_not_found() {
+        let di = make_download_info(vec!["https://cdn1.example.com/manifest.json"]);
+        assert!(di
+            .get_distribution_point_by_base_url("https://cdn3")
+            .is_none());
+    }
+
+    #[test]
+    fn get_distribution_point_by_base_url_empty() {
+        let di = make_download_info(vec![]);
+        assert!(di
+            .get_distribution_point_by_base_url("https://anything")
+            .is_none());
+    }
+}

--- a/src/api/types/friends.rs
+++ b/src/api/types/friends.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// A friend record with relationship status.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/api/types/library.rs
+++ b/src/api/types/library.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// Paginated library response containing owned asset records.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -8,6 +9,7 @@ pub struct Library {
     pub response_metadata: Option<ResponseMetadata>,
 }
 
+/// A single library entry referencing an owned asset.
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/api/types/mod.rs
+++ b/src/api/types/mod.rs
@@ -30,3 +30,27 @@ pub mod fab_library;
 
 /// Fab Asset Manifest
 pub mod fab_asset_manifest;
+
+/// Catalog Item structures
+pub mod catalog_item;
+
+/// Catalog Offer structures
+pub mod catalog_offer;
+
+/// Currency structures
+pub mod currency;
+
+/// Price structures
+pub mod price;
+
+/// Service Status structures
+pub mod service_status;
+
+/// Presence structures
+pub mod presence;
+
+/// Billing Account structures
+pub mod billing_account;
+
+/// Quick Purchase structures
+pub mod quick_purchase;

--- a/src/api/types/presence.rs
+++ b/src/api/types/presence.rs
@@ -1,0 +1,19 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from a presence update (PATCH).
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenceUpdate {
+    pub status: Option<String>,
+    pub activity: Option<PresenceActivity>,
+}
+
+/// Activity details within a presence payload.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PresenceActivity {
+    pub r#type: Option<String>,
+    pub properties: Option<serde_json::Value>,
+}

--- a/src/api/types/price.rs
+++ b/src/api/types/price.rs
@@ -1,0 +1,54 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from the price engine for offer pricing.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceResponse {
+    #[serde(default)]
+    pub offers: Vec<OfferPrice>,
+}
+
+/// Price details for a single offer.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OfferPrice {
+    pub offer_id: String,
+    pub namespace: Option<String>,
+    pub effective_date: Option<String>,
+    pub expiry_date: Option<String>,
+    pub current_price: Option<PriceDetail>,
+}
+
+/// Breakdown of a price entry.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceDetail {
+    pub currency_code: Option<String>,
+    pub discount_price: Option<i64>,
+    pub original_price: Option<i64>,
+    pub voucher_discount: Option<i64>,
+    pub discount_percentage: Option<i64>,
+    pub currency_info: Option<PriceCurrencyInfo>,
+    pub fmt_price: Option<FormattedPrice>,
+}
+
+/// Currency info embedded in a price response.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PriceCurrencyInfo {
+    pub decimals: Option<i32>,
+}
+
+/// Pre-formatted price strings.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FormattedPrice {
+    pub original_price: Option<String>,
+    pub discount_price: Option<String>,
+    pub intermediate_price: Option<String>,
+}

--- a/src/api/types/quick_purchase.rs
+++ b/src/api/types/quick_purchase.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from a quick purchase (free claim) request.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct QuickPurchaseResponse {
+    pub order_id: Option<String>,
+    pub status: Option<String>,
+    pub namespace: Option<String>,
+    pub offer_id: Option<String>,
+}

--- a/src/api/types/service_status.rs
+++ b/src/api/types/service_status.rs
@@ -1,0 +1,27 @@
+use serde::{Deserialize, Serialize};
+
+/// Status of an Epic online service (from lightswitch API).
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ServiceStatus {
+    pub service_instance_id: String,
+    pub status: String,
+    pub message: Option<String>,
+    pub maintenance_uri: Option<String>,
+    #[serde(default)]
+    pub override_catalog_ids: Vec<String>,
+    pub allowed_actions: Option<Vec<String>>,
+    pub banned: Option<bool>,
+    pub launcher_info_dto: Option<LauncherInfo>,
+}
+
+/// Launcher-specific info within a service status.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LauncherInfo {
+    pub app_name: Option<String>,
+    pub catalog_item_id: Option<String>,
+    pub namespace: Option<String>,
+}

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -90,7 +90,7 @@ pub(crate) fn decode_hex(s: &str) -> Result<Vec<u8>, ParseIntError> {
         .collect()
 }
 
-pub(crate) fn write_fstring(string: String) -> Vec<u8> {
+pub(crate) fn write_fstring(string: &str) -> Vec<u8> {
     let mut meta: Vec<u8> = Vec::new();
     if !string.is_empty() {
         meta.append(
@@ -99,7 +99,7 @@ pub(crate) fn write_fstring(string: String) -> Vec<u8> {
                 .to_vec()
                 .borrow_mut(),
         );
-        meta.append(string.into_bytes().borrow_mut());
+        meta.append(string.as_bytes().to_vec().borrow_mut());
         meta.push(0);
     } else {
         meta.append(0u32.to_le_bytes().to_vec().borrow_mut())
@@ -198,20 +198,20 @@ mod tests {
 
     #[test]
     fn write_fstring_nonempty() {
-        let buffer = write_fstring("hello".to_string());
+        let buffer = write_fstring("hello");
         assert_eq!(buffer, vec![6, 0, 0, 0, 104, 101, 108, 108, 111, 0])
     }
 
     #[test]
     fn write_fstring_empty() {
-        let buffer = write_fstring("".to_string());
+        let buffer = write_fstring("");
         assert_eq!(buffer, vec![0, 0, 0, 0])
     }
 
     #[test]
     fn write_fstring_roundtrip() {
         let original = "roundtrip".to_string();
-        let buffer = write_fstring(original.clone());
+        let buffer = write_fstring(&original);
         let mut position: usize = 0;
         assert_eq!(read_fstring(&buffer, &mut position), Some(original));
     }

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -1,9 +1,9 @@
 use num::{BigUint, Zero};
-use std::convert::TryInto;
-use std::ops::Shl;
 use std::borrow::BorrowMut;
-use std::num::ParseIntError;
 use std::cmp::Ordering;
+use std::convert::TryInto;
+use std::num::ParseIntError;
+use std::ops::Shl;
 
 /// Convert numbers in the Download Manifest from little indian and %03d concatenated string
 pub fn blob_to_num<T: Into<String>>(str: T) -> u128 {
@@ -72,7 +72,7 @@ pub(crate) fn read_fstring(buffer: &[u8], position: &mut usize) -> Option<String
                     .as_slice(),
             ))
         }
-        Ordering::Equal => { None }
+        Ordering::Equal => None,
         Ordering::Greater => {
             *position += length as usize;
             match std::str::from_utf8(&buffer[*position - length as usize..*position - 1]) {
@@ -110,8 +110,8 @@ pub(crate) fn write_fstring(string: String) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use crate::api::utils::{
-        bigblob_to_num, blob_to_num, do_vecs_match, read_fstring, read_le, read_le_64,
-        read_le_64_signed, read_le_signed,
+        bigblob_to_num, blob_to_num, decode_hex, do_vecs_match, read_fstring, read_le, read_le_64,
+        read_le_64_signed, read_le_signed, write_fstring,
     };
     use num::bigint::ToBigUint;
 
@@ -194,5 +194,69 @@ mod tests {
             Some("abcd".to_string())
         );
         assert_eq!(position, 14)
+    }
+
+    #[test]
+    fn write_fstring_nonempty() {
+        let buffer = write_fstring("hello".to_string());
+        assert_eq!(buffer, vec![6, 0, 0, 0, 104, 101, 108, 108, 111, 0])
+    }
+
+    #[test]
+    fn write_fstring_empty() {
+        let buffer = write_fstring("".to_string());
+        assert_eq!(buffer, vec![0, 0, 0, 0])
+    }
+
+    #[test]
+    fn write_fstring_roundtrip() {
+        let original = "roundtrip".to_string();
+        let buffer = write_fstring(original.clone());
+        let mut position: usize = 0;
+        assert_eq!(read_fstring(&buffer, &mut position), Some(original));
+    }
+
+    #[test]
+    fn decode_hex_valid() {
+        assert_eq!(
+            decode_hex("48656c6c6f").unwrap(),
+            vec![72, 101, 108, 108, 111]
+        )
+    }
+
+    #[test]
+    fn decode_hex_empty() {
+        assert_eq!(decode_hex("").unwrap(), Vec::<u8>::new())
+    }
+
+    #[test]
+    fn decode_hex_invalid() {
+        assert!(decode_hex("zz").is_err())
+    }
+
+    #[test]
+    fn read_fstring_zero_length() {
+        let mut position: usize = 0;
+        let buffer = vec![0, 0, 0, 0];
+        assert_eq!(read_fstring(&buffer, &mut position), None);
+        assert_eq!(position, 4)
+    }
+
+    #[test]
+    fn read_fstring_invalid_utf8() {
+        let mut position: usize = 0;
+        let buffer = vec![3, 0, 0, 0, 255, 254, 0];
+        assert_eq!(read_fstring(&buffer, &mut position), None);
+        assert_eq!(position, 7)
+    }
+
+    #[test]
+    fn blob_to_num_empty() {
+        assert_eq!(blob_to_num(""), 0)
+    }
+
+    #[test]
+    fn blob_to_num_single() {
+        assert_eq!(blob_to_num("042"), 42)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,6 +174,17 @@ impl EpicGames {
         self.egs.user_data.update(user_details);
     }
 
+    /// Like [`auth_code`](Self::auth_code), but returns a `Result` instead of swallowing errors.
+    pub async fn try_auth_code(
+        &mut self,
+        exchange_token: Option<String>,
+        authorization_code: Option<String>,
+    ) -> Result<bool, EpicAPIError> {
+        self.egs
+            .start_session(exchange_token, authorization_code)
+            .await
+    }
+
     /// Authenticate with an authorization code or exchange token.
     ///
     /// Returns `true` on success, `false` on failure. Returns `None` on API errors.
@@ -182,8 +193,7 @@ impl EpicGames {
         exchange_token: Option<String>,
         authorization_code: Option<String>,
     ) -> bool {
-        self.egs
-            .start_session(exchange_token, authorization_code)
+        self.try_auth_code(exchange_token, authorization_code)
             .await
             .unwrap_or(false)
     }
@@ -193,9 +203,48 @@ impl EpicGames {
         self.egs.invalidate_sesion().await
     }
 
+    /// Like [`login`](Self::login), but returns a `Result` instead of swallowing errors.
+    pub async fn try_login(&mut self) -> Result<bool, EpicAPIError> {
+        if let Some(exp) = self.egs.user_data.expires_at {
+            let now = chrono::offset::Utc::now();
+            let td = exp - now;
+            if td.num_seconds() > 600 {
+                info!("Trying to re-use existing login session... ");
+                let resumed = self.egs.resume_session().await.map_err(|e| {
+                    warn!("{}", e);
+                    e
+                })?;
+                if resumed {
+                    info!("Logged in");
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+        }
+        info!("Logging in...");
+        if let Some(exp) = self.egs.user_data.refresh_expires_at {
+            let now = chrono::offset::Utc::now();
+            let td = exp - now;
+            if td.num_seconds() > 600 {
+                let started = self.egs.start_session(None, None).await.map_err(|e| {
+                    error!("{}", e);
+                    e
+                })?;
+                if started {
+                    info!("Logged in");
+                    return Ok(true);
+                }
+                return Ok(false);
+            }
+        }
+        Ok(false)
+    }
+
     /// Resume session using the saved refresh token.
     ///
     /// Returns `true` on success, `false` if the refresh token has expired or is invalid.
+    /// Unlike [`try_login`](Self::try_login), this method falls through to
+    /// refresh-token login if session resume fails.
     pub async fn login(&mut self) -> bool {
         if let Some(exp) = self.egs.user_data.expires_at {
             let now = chrono::offset::Utc::now();
@@ -238,6 +287,15 @@ impl EpicGames {
         false
     }
 
+    /// Like [`list_assets`](Self::list_assets), but returns a `Result` instead of swallowing errors.
+    pub async fn try_list_assets(
+        &mut self,
+        platform: Option<String>,
+        label: Option<String>,
+    ) -> Result<Vec<EpicAsset>, EpicAPIError> {
+        self.egs.assets(platform, label).await
+    }
+
     /// List all owned assets.
     ///
     /// Defaults to platform="Windows" and label="Live" if not specified.
@@ -247,10 +305,23 @@ impl EpicGames {
         platform: Option<String>,
         label: Option<String>,
     ) -> Vec<EpicAsset> {
-        self.egs
-            .assets(platform, label)
+        self.try_list_assets(platform, label)
             .await
             .unwrap_or_else(|_| Vec::new())
+    }
+
+    /// Like [`asset_manifest`](Self::asset_manifest), but returns a `Result` instead of swallowing errors.
+    pub async fn try_asset_manifest(
+        &mut self,
+        platform: Option<String>,
+        label: Option<String>,
+        namespace: Option<String>,
+        item_id: Option<String>,
+        app: Option<String>,
+    ) -> Result<AssetManifest, EpicAPIError> {
+        self.egs
+            .asset_manifest(platform, label, namespace, item_id, app)
+            .await
     }
 
     /// Fetch asset manifest with CDN download URLs.
@@ -265,14 +336,9 @@ impl EpicGames {
         item_id: Option<String>,
         app: Option<String>,
     ) -> Option<AssetManifest> {
-        match self
-            .egs
-            .asset_manifest(platform, label, namespace, item_id, app)
+        self.try_asset_manifest(platform, label, namespace, item_id, app)
             .await
-        {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+            .ok()
     }
 
     /// Fetch Fab asset manifest with signed distribution points.
@@ -295,81 +361,118 @@ impl EpicGames {
         }
     }
 
+    /// Like [`asset_info`](Self::asset_info), but returns a `Result` instead of swallowing errors.
+    pub async fn try_asset_info(
+        &mut self,
+        asset: &EpicAsset,
+    ) -> Result<Option<AssetInfo>, EpicAPIError> {
+        let mut info = self.egs.asset_info(asset).await?;
+        Ok(info.remove(asset.catalog_item_id.as_str()))
+    }
+
     /// Fetch catalog metadata for an asset (includes DLC tree).
     ///
     /// Returns `None` on API errors.
     pub async fn asset_info(&mut self, asset: &EpicAsset) -> Option<AssetInfo> {
-        match self.egs.asset_info(asset).await {
-            Ok(mut a) => a.remove(asset.catalog_item_id.as_str()),
-            Err(_) => None,
-        }
+        self.try_asset_info(asset).await.ok().flatten()
+    }
+
+    /// Like [`account_details`](Self::account_details), but returns a `Result` instead of swallowing errors.
+    pub async fn try_account_details(&mut self) -> Result<AccountData, EpicAPIError> {
+        self.egs.account_details().await
     }
 
     /// Fetch account details (email, display name, country, 2FA status).
     ///
     /// Returns `None` on API errors.
     pub async fn account_details(&mut self) -> Option<AccountData> {
-        match self.egs.account_details().await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_account_details().await.ok()
+    }
+
+    /// Like [`account_ids_details`](Self::account_ids_details), but returns a `Result` instead of swallowing errors.
+    pub async fn try_account_ids_details(
+        &mut self,
+        ids: Vec<String>,
+    ) -> Result<Vec<AccountInfo>, EpicAPIError> {
+        self.egs.account_ids_details(ids).await
     }
 
     /// Bulk lookup of account IDs to display names.
     ///
     /// Returns `None` on API errors.
     pub async fn account_ids_details(&mut self, ids: Vec<String>) -> Option<Vec<AccountInfo>> {
-        match self.egs.account_ids_details(ids).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_account_ids_details(ids).await.ok()
+    }
+
+    /// Like [`account_friends`](Self::account_friends), but returns a `Result` instead of swallowing errors.
+    pub async fn try_account_friends(
+        &mut self,
+        include_pending: bool,
+    ) -> Result<Vec<Friend>, EpicAPIError> {
+        self.egs.account_friends(include_pending).await
     }
 
     /// Fetch friends list (including pending requests if `include_pending` is true).
     ///
     /// Returns `None` on API errors.
     pub async fn account_friends(&mut self, include_pending: bool) -> Option<Vec<Friend>> {
-        match self.egs.account_friends(include_pending).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_account_friends(include_pending).await.ok()
+    }
+
+    /// Like [`game_token`](Self::game_token), but returns a `Result` instead of swallowing errors.
+    pub async fn try_game_token(&mut self) -> Result<GameToken, EpicAPIError> {
+        self.egs.game_token().await
     }
 
     /// Fetch a short-lived exchange code for game launches.
     ///
     /// Returns `None` on API errors.
     pub async fn game_token(&mut self) -> Option<GameToken> {
-        match self.egs.game_token().await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_game_token().await.ok()
+    }
+
+    /// Like [`ownership_token`](Self::ownership_token), but returns a `Result` instead of swallowing errors.
+    pub async fn try_ownership_token(&mut self, asset: &EpicAsset) -> Result<String, EpicAPIError> {
+        self.egs.ownership_token(asset).await.map(|a| a.token)
     }
 
     /// Fetch a JWT proving ownership of an asset.
     ///
     /// Returns `None` on API errors.
     pub async fn ownership_token(&mut self, asset: &EpicAsset) -> Option<String> {
-        match self.egs.ownership_token(asset).await {
-            Ok(a) => Some(a.token),
-            Err(_) => None,
-        }
+        self.try_ownership_token(asset).await.ok()
+    }
+
+    /// Like [`user_entitlements`](Self::user_entitlements), but returns a `Result` instead of swallowing errors.
+    pub async fn try_user_entitlements(&mut self) -> Result<Vec<Entitlement>, EpicAPIError> {
+        self.egs.user_entitlements().await
     }
 
     /// Fetch all user entitlements (games, DLC, subscriptions).
     ///
     /// Returns empty `Vec` on API errors.
     pub async fn user_entitlements(&mut self) -> Vec<Entitlement> {
-        self.egs.user_entitlements().await.unwrap_or_else(|_| Vec::new())
+        self.try_user_entitlements().await.unwrap_or_else(|_| Vec::new())
+    }
+
+    /// Like [`library_items`](Self::library_items), but returns a `Result` instead of swallowing errors.
+    pub async fn try_library_items(&mut self, include_metadata: bool) -> Result<Library, EpicAPIError> {
+        self.egs.library_items(include_metadata).await
     }
 
     /// Fetch the user library with optional metadata.
     ///
     /// Paginates internally and returns all records at once. Returns `None` on API errors.
     pub async fn library_items(&mut self, include_metadata: bool) -> Option<Library> {
-        match self.egs.library_items(include_metadata).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_library_items(include_metadata).await.ok()
+    }
+
+    /// Like [`fab_library_items`](Self::fab_library_items), but returns a `Result` instead of swallowing errors.
+    pub async fn try_fab_library_items(
+        &mut self,
+        account_id: String,
+    ) -> Result<api::types::fab_library::FabLibrary, EpicAPIError> {
+        self.egs.fab_library_items(account_id).await
     }
 
     /// Fetch the user Fab library.
@@ -379,10 +482,7 @@ impl EpicGames {
         &mut self,
         account_id: String,
     ) -> Option<api::types::fab_library::FabLibrary> {
-        match self.egs.fab_library_items(account_id).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_fab_library_items(account_id).await.ok()
     }
 
     /// Parse download manifests from all CDN mirrors.
@@ -406,6 +506,11 @@ impl EpicGames {
             .await
     }
 
+    /// Like [`auth_client_credentials`](Self::auth_client_credentials), but returns a `Result` instead of swallowing errors.
+    pub async fn try_auth_client_credentials(&mut self) -> Result<bool, EpicAPIError> {
+        self.egs.start_client_credentials_session().await
+    }
+
     /// Authenticate with client credentials (app-level, no user context).
     ///
     /// Uses the launcher's public client ID/secret to obtain an access token
@@ -415,10 +520,12 @@ impl EpicGames {
     ///
     /// Returns `true` on success, `false` on failure.
     pub async fn auth_client_credentials(&mut self) -> bool {
-        self.egs
-            .start_client_credentials_session()
-            .await
-            .unwrap_or(false)
+        self.try_auth_client_credentials().await.unwrap_or(false)
+    }
+
+    /// Like [`external_auths`](Self::external_auths), but returns a `Result` instead of swallowing errors.
+    pub async fn try_external_auths(&self, account_id: &str) -> Result<Vec<ExternalAuth>, EpicAPIError> {
+        self.egs.external_auths(account_id).await
     }
 
     /// Fetch external auth connections linked to an account.
@@ -428,10 +535,12 @@ impl EpicGames {
     ///
     /// Returns `None` on API errors.
     pub async fn external_auths(&self, account_id: &str) -> Option<Vec<ExternalAuth>> {
-        match self.egs.external_auths(account_id).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_external_auths(account_id).await.ok()
+    }
+
+    /// Like [`sso_domains`](Self::sso_domains), but returns a `Result` instead of swallowing errors.
+    pub async fn try_sso_domains(&self) -> Result<Vec<String>, EpicAPIError> {
+        self.egs.sso_domains().await
     }
 
     /// Fetch the list of SSO (Single Sign-On) domains.
@@ -441,10 +550,17 @@ impl EpicGames {
     ///
     /// Returns `None` on API errors.
     pub async fn sso_domains(&self) -> Option<Vec<String>> {
-        match self.egs.sso_domains().await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_sso_domains().await.ok()
+    }
+
+    /// Like [`catalog_items`](Self::catalog_items), but returns a `Result` instead of swallowing errors.
+    pub async fn try_catalog_items(
+        &self,
+        namespace: &str,
+        start: i64,
+        count: i64,
+    ) -> Result<CatalogItemPage, EpicAPIError> {
+        self.egs.catalog_items(namespace, start, count).await
     }
 
     /// Fetch paginated catalog items for a namespace.
@@ -461,10 +577,17 @@ impl EpicGames {
         start: i64,
         count: i64,
     ) -> Option<CatalogItemPage> {
-        match self.egs.catalog_items(namespace, start, count).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_catalog_items(namespace, start, count).await.ok()
+    }
+
+    /// Like [`catalog_offers`](Self::catalog_offers), but returns a `Result` instead of swallowing errors.
+    pub async fn try_catalog_offers(
+        &self,
+        namespace: &str,
+        start: i64,
+        count: i64,
+    ) -> Result<CatalogOfferPage, EpicAPIError> {
+        self.egs.catalog_offers(namespace, start, count).await
     }
 
     /// Fetch paginated catalog offers for a namespace.
@@ -480,10 +603,15 @@ impl EpicGames {
         start: i64,
         count: i64,
     ) -> Option<CatalogOfferPage> {
-        match self.egs.catalog_offers(namespace, start, count).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_catalog_offers(namespace, start, count).await.ok()
+    }
+
+    /// Like [`bulk_catalog_items`](Self::bulk_catalog_items), but returns a `Result` instead of swallowing errors.
+    pub async fn try_bulk_catalog_items(
+        &self,
+        items: &[(&str, &str)],
+    ) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, AssetInfo>>, EpicAPIError> {
+        self.egs.bulk_catalog_items(items).await
     }
 
     /// Bulk fetch catalog items across multiple namespaces.
@@ -497,10 +625,12 @@ impl EpicGames {
         &self,
         items: &[(&str, &str)],
     ) -> Option<std::collections::HashMap<String, std::collections::HashMap<String, AssetInfo>>> {
-        match self.egs.bulk_catalog_items(items).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_bulk_catalog_items(items).await.ok()
+    }
+
+    /// Like [`currencies`](Self::currencies), but returns a `Result` instead of swallowing errors.
+    pub async fn try_currencies(&self, start: i64, count: i64) -> Result<CurrencyPage, EpicAPIError> {
+        self.egs.currencies(start, count).await
     }
 
     /// Fetch available currencies from the Epic catalog.
@@ -510,10 +640,15 @@ impl EpicGames {
     ///
     /// Returns `None` on API errors.
     pub async fn currencies(&self, start: i64, count: i64) -> Option<CurrencyPage> {
-        match self.egs.currencies(start, count).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_currencies(start, count).await.ok()
+    }
+
+    /// Like [`library_state_token_status`](Self::library_state_token_status), but returns a `Result` instead of swallowing errors.
+    pub async fn try_library_state_token_status(
+        &self,
+        token_id: &str,
+    ) -> Result<bool, EpicAPIError> {
+        self.egs.library_state_token_status(token_id).await
     }
 
     /// Check the validity of a library state token.
@@ -524,10 +659,15 @@ impl EpicGames {
     ///
     /// Returns `None` on API errors.
     pub async fn library_state_token_status(&self, token_id: &str) -> Option<bool> {
-        match self.egs.library_state_token_status(token_id).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_library_state_token_status(token_id).await.ok()
+    }
+
+    /// Like [`service_status`](Self::service_status), but returns a `Result` instead of swallowing errors.
+    pub async fn try_service_status(
+        &self,
+        service_id: &str,
+    ) -> Result<Vec<ServiceStatus>, EpicAPIError> {
+        self.egs.service_status(service_id).await
     }
 
     /// Fetch service status from Epic's lightswitch API.
@@ -538,10 +678,17 @@ impl EpicGames {
     ///
     /// Returns `None` on API errors.
     pub async fn service_status(&self, service_id: &str) -> Option<Vec<ServiceStatus>> {
-        match self.egs.service_status(service_id).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_service_status(service_id).await.ok()
+    }
+
+    /// Like [`offer_prices`](Self::offer_prices), but returns a `Result` instead of swallowing errors.
+    pub async fn try_offer_prices(
+        &self,
+        namespace: &str,
+        offer_ids: &[String],
+        country: &str,
+    ) -> Result<PriceResponse, EpicAPIError> {
+        self.egs.offer_prices(namespace, offer_ids, country).await
     }
 
     /// Fetch offer prices from Epic's price engine.
@@ -557,10 +704,16 @@ impl EpicGames {
         offer_ids: &[String],
         country: &str,
     ) -> Option<PriceResponse> {
-        match self.egs.offer_prices(namespace, offer_ids, country).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_offer_prices(namespace, offer_ids, country).await.ok()
+    }
+
+    /// Like [`quick_purchase`](Self::quick_purchase), but returns a `Result` instead of swallowing errors.
+    pub async fn try_quick_purchase(
+        &self,
+        namespace: &str,
+        offer_id: &str,
+    ) -> Result<QuickPurchaseResponse, EpicAPIError> {
+        self.egs.quick_purchase(namespace, offer_id).await
     }
 
     /// Execute a quick purchase (typically for free game claims).
@@ -575,10 +728,12 @@ impl EpicGames {
         namespace: &str,
         offer_id: &str,
     ) -> Option<QuickPurchaseResponse> {
-        match self.egs.quick_purchase(namespace, offer_id).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_quick_purchase(namespace, offer_id).await.ok()
+    }
+
+    /// Like [`billing_account`](Self::billing_account), but returns a `Result` instead of swallowing errors.
+    pub async fn try_billing_account(&self) -> Result<BillingAccount, EpicAPIError> {
+        self.egs.billing_account().await
     }
 
     /// Fetch the default billing account for payment processing.
@@ -588,10 +743,7 @@ impl EpicGames {
     ///
     /// Returns `None` on API errors.
     pub async fn billing_account(&self) -> Option<BillingAccount> {
-        match self.egs.billing_account().await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_billing_account().await.ok()
     }
 
     /// Update the user's presence status.
@@ -608,6 +760,18 @@ impl EpicGames {
         self.egs.update_presence(session_id, body).await
     }
 
+    /// Like [`fab_file_download_info`](Self::fab_file_download_info), but returns a `Result` instead of swallowing errors.
+    pub async fn try_fab_file_download_info(
+        &self,
+        listing_id: &str,
+        format_id: &str,
+        file_id: &str,
+    ) -> Result<DownloadInfo, EpicAPIError> {
+        self.egs
+            .fab_file_download_info(listing_id, format_id, file_id)
+            .await
+    }
+
     /// Fetch download info for a specific file within a Fab listing.
     ///
     /// Returns signed [`DownloadInfo`] for a single file identified by
@@ -622,10 +786,9 @@ impl EpicGames {
         format_id: &str,
         file_id: &str,
     ) -> Option<DownloadInfo> {
-        match self.egs.fab_file_download_info(listing_id, format_id, file_id).await {
-            Ok(a) => Some(a),
-            Err(_) => None,
-        }
+        self.try_fab_file_download_info(listing_id, format_id, file_id)
+            .await
+            .ok()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,22 +3,89 @@
 
 //! # Epic Games Store API
 //!
-//! A minimal asynchronous interface to Epic Games Store
+//! Async Rust client for the Epic Games Store API. Provides authentication,
+//! asset management, download manifest parsing (binary + JSON), and
+//! [Fab](https://www.fab.com/) marketplace integration.
 //!
-//! # This is under heavy development expect major breaking changes
+//! # Quick Start
 //!
-//! ## Current functionality
-//!  - Authentication
-//!  - Listing Assets
-//!  - Get Asset metadata
-//!  - Get Asset info
-//!  - Get Ownership Token
-//!  - Get Game Token
-//!  - Get Entitlements
-//!  - Get Library Items
-//!  - Generate download links for chunks
+//! ```rust,no_run
+//! use egs_api::EpicGames;
+//!
+//! #[tokio::main]
+//! async fn main() {
+//!     let mut egs = EpicGames::new();
+//!
+//!     // Authenticate with an authorization code
+//!     let code = "your_authorization_code".to_string();
+//!     if egs.auth_code(None, Some(code)).await {
+//!         println!("Logged in as {}", egs.user_details().display_name.unwrap_or_default());
+//!     }
+//!
+//!     // List all owned assets
+//!     let assets = egs.list_assets(None, None).await;
+//!     println!("You own {} assets", assets.len());
+//! }
+//! ```
+//!
+//! # Authentication
+//!
+//! Epic uses OAuth2 with a public launcher client ID. The flow is:
+//!
+//! 1. Open the [authorization URL] in a browser — the user logs in and gets
+//!    redirected to a JSON page with an `authorizationCode`.
+//! 2. Pass that code to [`EpicGames::auth_code`].
+//! 3. Persist the session with [`EpicGames::user_details`] (implements
+//!    `Serialize` / `Deserialize`).
+//! 4. Restore it later with [`EpicGames::set_user_details`] +
+//!    [`EpicGames::login`], which uses the refresh token.
+//!
+//! [authorization URL]: https://www.epicgames.com/id/login?redirectUrl=https%3A%2F%2Fwww.epicgames.com%2Fid%2Fapi%2Fredirect%3FclientId%3D34a02cf8f4414e29b15921876da36f9a%26responseType%3Dcode
+//!
+//! # Features
+//!
+//! - **Assets** — List owned assets, fetch catalog metadata (with DLC trees),
+//!   retrieve asset manifests with CDN download URLs.
+//! - **Download Manifests** — Parse Epic's binary and JSON manifest formats.
+//!   Exposes file lists, chunk hashes, and custom fields for download
+//!   reconstruction.
+//! - **Fab Marketplace** — List Fab library items, fetch signed asset manifests,
+//!   and download manifests from distribution points.
+//! - **Account** — Details, bulk ID lookup, friends list.
+//! - **Entitlements** — Games, DLC, subscriptions.
+//! - **Library** — Paginated listing with optional metadata.
+//! - **Tokens** — Game exchange tokens and per-asset ownership tokens (JWT).
+//!
+//! # Architecture
+//!
+//! [`EpicGames`] is the public facade. It wraps an internal `EpicAPI` struct
+//! that holds the `reqwest::Client` (with cookie store) and session state.
+//! Most public methods return `Option<T>` or `Vec<T>`, swallowing transport
+//! errors for convenience. Fab methods return `Result<T, EpicAPIError>` to
+//! expose timeout/error distinctions.
+//!
+//! # Examples
+//!
+//! The crate ships with examples covering every endpoint. See the
+//! [`examples/`](https://github.com/AchetaGames/egs-api-rs/tree/master/examples)
+//! directory or run:
+//!
+//! ```bash
+//! cargo run --example auth                # Interactive login + token persistence
+//! cargo run --example account             # Account details, ID lookup, friends, external auths, SSO
+//! cargo run --example entitlements        # List all entitlements
+//! cargo run --example library             # Paginated library listing
+//! cargo run --example assets              # Full pipeline: list → info → manifest → download
+//! cargo run --example game_token          # Exchange code + ownership token
+//! cargo run --example fab                 # Fab library → asset manifest → download manifest
+//! cargo run --example catalog             # Catalog items, offers, bulk lookup
+//! cargo run --example commerce            # Currencies, prices, billing, quick purchase
+//! cargo run --example status              # Service status (lightswitch API)
+//! cargo run --example presence            # Update online presence
+//! cargo run --example client_credentials  # App-level auth + library state tokens
+//! ```
 
-use crate::api::types::account::{AccountData, AccountInfo, UserData};
+use crate::api::types::account::{AccountData, AccountInfo, ExternalAuth, UserData};
 use crate::api::types::epic_asset::EpicAsset;
 use crate::api::types::fab_asset_manifest::DownloadInfo;
 use crate::api::types::friends::Friend;
@@ -26,30 +93,58 @@ use crate::api::{EpicAPI};
 
 use api::types::asset_info::{AssetInfo, GameToken};
 use api::types::asset_manifest::AssetManifest;
+use api::types::billing_account::BillingAccount;
+use api::types::catalog_item::CatalogItemPage;
+use api::types::catalog_offer::CatalogOfferPage;
+use api::types::currency::CurrencyPage;
 use api::types::download_manifest::DownloadManifest;
 use api::types::entitlement::Entitlement;
 use api::types::library::Library;
+use api::types::presence::PresenceUpdate;
+use api::types::price::PriceResponse;
+use api::types::quick_purchase::QuickPurchaseResponse;
+use api::types::service_status::ServiceStatus;
 use log::{error, info, warn};
 use crate::api::error::EpicAPIError;
 
 /// Module for authenticated API communication
 pub mod api;
 
-/// Struct to manage the communication with the Epic Games Store Api
-#[derive(Default, Debug, Clone)]
+/// Client for the Epic Games Store API.
+///
+/// This is the main entry point for the library. Create an instance with
+/// [`EpicGames::new`], authenticate with [`EpicGames::auth_code`] or
+/// [`EpicGames::login`], then call API methods.
+///
+/// Most methods return `Option<T>` or `Vec<T>`, returning `None` / empty on
+/// errors. Fab methods return `Result<T, EpicAPIError>` for richer error
+/// handling (e.g., distinguishing timeouts from other failures).
+///
+/// Session state is stored in [`UserData`], which implements
+/// `Serialize` / `Deserialize` for persistence across runs.
+#[derive(Debug, Clone)]
 pub struct EpicGames {
     egs: EpicAPI,
 }
 
+impl Default for EpicGames {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EpicGames {
-    /// Creates new object
+    /// Creates a new [`EpicGames`] client.
     pub fn new() -> Self {
         EpicGames {
             egs: EpicAPI::new(),
         }
     }
 
-    /// Check whether the user is logged in
+    /// Check whether the user is logged in.
+    ///
+    /// Returns `true` if the access token exists and has more than 600 seconds
+    /// remaining before expiry.
     pub fn is_logged_in(&self) -> bool {
         if let Some(exp) = self.egs.user_data.expires_at {
             let now = chrono::offset::Utc::now();
@@ -61,17 +156,27 @@ impl EpicGames {
         false
     }
 
-    /// Get User details
+    /// Returns a clone of the current session state.
+    ///
+    /// The returned [`UserData`] implements `Serialize` / `Deserialize`,
+    /// so you can persist it to disk and restore it later with
+    /// [`set_user_details`](Self::set_user_details).
     pub fn user_details(&self) -> UserData {
         self.egs.user_data.clone()
     }
 
-    /// Update User Details
+    /// Restore session state from a previously saved [`UserData`].
+    ///
+    /// Only merges `Some` fields — existing values are preserved for any
+    /// field that is `None` in the input. Call [`login`](Self::login)
+    /// afterward to refresh the access token.
     pub fn set_user_details(&mut self, user_details: UserData) {
         self.egs.user_data.update(user_details);
     }
 
-    /// Start session with auth code
+    /// Authenticate with an authorization code or exchange token.
+    ///
+    /// Returns `true` on success, `false` on failure. Returns `None` on API errors.
     pub async fn auth_code(
         &mut self,
         exchange_token: Option<String>,
@@ -83,12 +188,14 @@ impl EpicGames {
             .unwrap_or(false)
     }
 
-    /// Invalidate existing session
+    /// Invalidate the current session and log out.
     pub async fn logout(&mut self) -> bool {
         self.egs.invalidate_sesion().await
     }
 
-    /// Perform login based on previous authentication
+    /// Resume session using the saved refresh token.
+    ///
+    /// Returns `true` on success, `false` if the refresh token has expired or is invalid.
     pub async fn login(&mut self) -> bool {
         if let Some(exp) = self.egs.user_data.expires_at {
             let now = chrono::offset::Utc::now();
@@ -131,7 +238,10 @@ impl EpicGames {
         false
     }
 
-    /// Returns all assets
+    /// List all owned assets.
+    ///
+    /// Defaults to platform="Windows" and label="Live" if not specified.
+    /// Returns empty `Vec` on API errors.
     pub async fn list_assets(
         &mut self,
         platform: Option<String>,
@@ -143,7 +253,10 @@ impl EpicGames {
             .unwrap_or_else(|_| Vec::new())
     }
 
-    /// Return asset
+    /// Fetch asset manifest with CDN download URLs.
+    ///
+    /// Defaults to platform="Windows" and label="Live" if not specified.
+    /// Returns `None` on API errors.
     pub async fn asset_manifest(
         &mut self,
         platform: Option<String>,
@@ -162,7 +275,9 @@ impl EpicGames {
         }
     }
 
-    /// Return Fab Asset Manifest
+    /// Fetch Fab asset manifest with signed distribution points.
+    ///
+    /// Returns `Result` to expose timeout errors (403 → `EpicAPIError::FabTimeout`).
     pub async fn fab_asset_manifest(
         &self,
         artifact_id: &str,
@@ -180,7 +295,9 @@ impl EpicGames {
         }
     }
 
-    /// Returns info for an asset
+    /// Fetch catalog metadata for an asset (includes DLC tree).
+    ///
+    /// Returns `None` on API errors.
     pub async fn asset_info(&mut self, asset: EpicAsset) -> Option<AssetInfo> {
         match self.egs.asset_info(asset.clone()).await {
             Ok(mut a) => a.remove(asset.catalog_item_id.as_str()),
@@ -188,7 +305,9 @@ impl EpicGames {
         }
     }
 
-    /// Returns account details
+    /// Fetch account details (email, display name, country, 2FA status).
+    ///
+    /// Returns `None` on API errors.
     pub async fn account_details(&mut self) -> Option<AccountData> {
         match self.egs.account_details().await {
             Ok(a) => Some(a),
@@ -196,7 +315,9 @@ impl EpicGames {
         }
     }
 
-    /// Returns account id info
+    /// Bulk lookup of account IDs to display names.
+    ///
+    /// Returns `None` on API errors.
     pub async fn account_ids_details(&mut self, ids: Vec<String>) -> Option<Vec<AccountInfo>> {
         match self.egs.account_ids_details(ids).await {
             Ok(a) => Some(a),
@@ -204,7 +325,9 @@ impl EpicGames {
         }
     }
 
-    /// Returns account id info
+    /// Fetch friends list (including pending requests if `include_pending` is true).
+    ///
+    /// Returns `None` on API errors.
     pub async fn account_friends(&mut self, include_pending: bool) -> Option<Vec<Friend>> {
         match self.egs.account_friends(include_pending).await {
             Ok(a) => Some(a),
@@ -212,7 +335,9 @@ impl EpicGames {
         }
     }
 
-    /// Returns game token
+    /// Fetch a short-lived exchange code for game launches.
+    ///
+    /// Returns `None` on API errors.
     pub async fn game_token(&mut self) -> Option<GameToken> {
         match self.egs.game_token().await {
             Ok(a) => Some(a),
@@ -220,7 +345,9 @@ impl EpicGames {
         }
     }
 
-    /// Returns ownership token for an Asset
+    /// Fetch a JWT proving ownership of an asset.
+    ///
+    /// Returns `None` on API errors.
     pub async fn ownership_token(&mut self, asset: EpicAsset) -> Option<String> {
         match self.egs.ownership_token(asset).await {
             Ok(a) => Some(a.token),
@@ -228,12 +355,16 @@ impl EpicGames {
         }
     }
 
-    ///Returns user entitlements
+    /// Fetch all user entitlements (games, DLC, subscriptions).
+    ///
+    /// Returns empty `Vec` on API errors.
     pub async fn user_entitlements(&mut self) -> Vec<Entitlement> {
         self.egs.user_entitlements().await.unwrap_or_else(|_| Vec::new())
     }
 
-    /// Returns the user library
+    /// Fetch the user library with optional metadata.
+    ///
+    /// Paginates internally and returns all records at once. Returns `None` on API errors.
     pub async fn library_items(&mut self, include_metadata: bool) -> Option<Library> {
         match self.egs.library_items(include_metadata).await {
             Ok(a) => Some(a),
@@ -241,7 +372,9 @@ impl EpicGames {
         }
     }
 
-    /// Returns the user FAB library
+    /// Fetch the user Fab library.
+    ///
+    /// Paginates internally and returns all records at once. Returns `None` on API errors.
     pub async fn fab_library_items(
         &mut self,
         account_id: String,
@@ -252,12 +385,17 @@ impl EpicGames {
         }
     }
 
-    /// Returns a DownloadManifest for a specified file manifest
+    /// Parse download manifests from all CDN mirrors.
+    ///
+    /// Fetches from all mirrors, parses binary/JSON format, and populates custom fields
+    /// (BaseUrl, CatalogItemId, etc.). Returns empty `Vec` on API errors.
     pub async fn asset_download_manifests(&self, manifest: AssetManifest) -> Vec<DownloadManifest> {
         self.egs.asset_download_manifests(manifest).await
     }
 
-    /// Return a Download Manifest for specified FAB download and url
+    /// Parse a Fab download manifest from a specific distribution point.
+    ///
+    /// Checks signature expiration before fetching. Returns `Result` to expose timeout errors.
     pub async fn fab_download_manifest(
         &self,
         download_info: DownloadInfo,
@@ -266,5 +404,288 @@ impl EpicGames {
         self.egs
             .fab_download_manifest(download_info, distribution_point_url)
             .await
+    }
+
+    /// Authenticate with client credentials (app-level, no user context).
+    ///
+    /// Uses the launcher's public client ID/secret to obtain an access token
+    /// without any user interaction. The resulting session has limited
+    /// permissions — it can query public endpoints (catalog, service status,
+    /// currencies) but cannot access user-specific data (library, entitlements).
+    ///
+    /// Returns `true` on success, `false` on failure.
+    pub async fn auth_client_credentials(&mut self) -> bool {
+        self.egs
+            .start_client_credentials_session()
+            .await
+            .unwrap_or(false)
+    }
+
+    /// Fetch external auth connections linked to an account.
+    ///
+    /// Returns linked platform accounts (Steam, PSN, Xbox, Nintendo, etc.)
+    /// with external display names and account IDs. Requires a valid user session.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn external_auths(&self, account_id: &str) -> Option<Vec<ExternalAuth>> {
+        match self.egs.external_auths(account_id).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Fetch the list of SSO (Single Sign-On) domains.
+    ///
+    /// Returns domain strings that support Epic's SSO flow. Used by the
+    /// launcher to determine which domains can share authentication cookies.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn sso_domains(&self) -> Option<Vec<String>> {
+        match self.egs.sso_domains().await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Fetch paginated catalog items for a namespace.
+    ///
+    /// Queries the Epic catalog service for items within a given namespace
+    /// (e.g., a game's namespace). Results are paginated — use `start` and
+    /// `count` to page through. Each [`CatalogItemPage`] includes a `paging`
+    /// field with the total count.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn catalog_items(
+        &self,
+        namespace: &str,
+        start: i64,
+        count: i64,
+    ) -> Option<CatalogItemPage> {
+        match self.egs.catalog_items(namespace, start, count).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Fetch paginated catalog offers for a namespace.
+    ///
+    /// Queries the Epic catalog service for offers (purchasable items) within
+    /// a namespace. Offers include pricing metadata, seller info, and linked
+    /// catalog items. Use `start` and `count` to paginate.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn catalog_offers(
+        &self,
+        namespace: &str,
+        start: i64,
+        count: i64,
+    ) -> Option<CatalogOfferPage> {
+        match self.egs.catalog_offers(namespace, start, count).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Bulk fetch catalog items across multiple namespaces.
+    ///
+    /// Accepts a slice of `(namespace, item_id)` pairs and returns them grouped
+    /// by namespace → item_id → [`AssetInfo`]. Useful for resolving catalog
+    /// metadata for items from different games in a single request.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn bulk_catalog_items(
+        &self,
+        items: &[(&str, &str)],
+    ) -> Option<std::collections::HashMap<String, std::collections::HashMap<String, AssetInfo>>> {
+        match self.egs.bulk_catalog_items(items).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Fetch available currencies from the Epic catalog.
+    ///
+    /// Returns paginated currency definitions including code, symbol, and
+    /// decimal precision. Use `start` and `count` to paginate.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn currencies(&self, start: i64, count: i64) -> Option<CurrencyPage> {
+        match self.egs.currencies(start, count).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Check the validity of a library state token.
+    ///
+    /// Returns `Some(true)` if the token is still valid, `Some(false)` if
+    /// expired or invalid, or `None` on API errors. Library state tokens are
+    /// used to detect changes to the user's library since the last sync.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn library_state_token_status(&self, token_id: &str) -> Option<bool> {
+        match self.egs.library_state_token_status(token_id).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Fetch service status from Epic's lightswitch API.
+    ///
+    /// Returns the operational status of an Epic online service (e.g., a game's
+    /// backend). The response includes whether the service is UP/DOWN, any
+    /// maintenance message, and whether the current user is banned.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn service_status(&self, service_id: &str) -> Option<Vec<ServiceStatus>> {
+        match self.egs.service_status(service_id).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Fetch offer prices from Epic's price engine.
+    ///
+    /// Queries current pricing for one or more offers within a namespace,
+    /// localized to a specific country. The response includes original price,
+    /// discount price, and pre-formatted display strings.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn offer_prices(
+        &self,
+        namespace: &str,
+        offer_ids: &[String],
+        country: &str,
+    ) -> Option<PriceResponse> {
+        match self.egs.offer_prices(namespace, offer_ids, country).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Execute a quick purchase (typically for free game claims).
+    ///
+    /// Initiates a purchase order for a free offer. The response contains the
+    /// order ID and its processing status. For paid offers, use the full
+    /// checkout flow in the Epic Games launcher instead.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn quick_purchase(
+        &self,
+        namespace: &str,
+        offer_id: &str,
+    ) -> Option<QuickPurchaseResponse> {
+        match self.egs.quick_purchase(namespace, offer_id).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Fetch the default billing account for payment processing.
+    ///
+    /// Returns the account's billing country, which is used to determine
+    /// regional pricing and payment availability.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn billing_account(&self) -> Option<BillingAccount> {
+        match self.egs.billing_account().await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+
+    /// Update the user's presence status.
+    ///
+    /// Sends a PATCH request to update the user's online presence (e.g.,
+    /// "online", "away") and optionally set an activity with custom properties.
+    /// The `session_id` is the OAuth session token from login. Returns `Ok(())`
+    /// on success (204 No Content) or an [`EpicAPIError`] on failure.
+    pub async fn update_presence(
+        &self,
+        session_id: &str,
+        body: &PresenceUpdate,
+    ) -> Result<(), EpicAPIError> {
+        self.egs.update_presence(session_id, body).await
+    }
+
+    /// Fetch download info for a specific file within a Fab listing.
+    ///
+    /// Returns signed [`DownloadInfo`] for a single file identified by
+    /// `listing_id`, `format_id`, and `file_id`. Use this for targeted
+    /// downloads of individual files from a Fab asset rather than fetching
+    /// the entire asset manifest.
+    ///
+    /// Returns `None` on API errors.
+    pub async fn fab_file_download_info(
+        &self,
+        listing_id: &str,
+        format_id: &str,
+        file_id: &str,
+    ) -> Option<DownloadInfo> {
+        match self.egs.fab_file_download_info(listing_id, format_id, file_id).await {
+            Ok(a) => Some(a),
+            Err(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod facade_tests {
+    use super::*;
+    use crate::api::types::account::UserData;
+    use chrono::{Duration, Utc};
+
+    #[test]
+    fn new_creates_instance() {
+        let egs = EpicGames::new();
+        assert!(!egs.is_logged_in());
+    }
+
+    #[test]
+    fn default_same_as_new() {
+        let egs = EpicGames::default();
+        assert!(!egs.is_logged_in());
+    }
+
+    #[test]
+    fn user_details_default_empty() {
+        let egs = EpicGames::new();
+        assert!(egs.user_details().access_token.is_none());
+    }
+
+    #[test]
+    fn set_and_get_user_details() {
+        let mut egs = EpicGames::new();
+        let mut ud = UserData::new();
+        ud.display_name = Some("TestUser".to_string());
+        egs.set_user_details(ud);
+        assert_eq!(egs.user_details().display_name, Some("TestUser".to_string()));
+    }
+
+    #[test]
+    fn is_logged_in_expired() {
+        let mut egs = EpicGames::new();
+        let mut ud = UserData::new();
+        ud.expires_at = Some(Utc::now() - Duration::hours(1));
+        egs.set_user_details(ud);
+        assert!(!egs.is_logged_in());
+    }
+
+    #[test]
+    fn is_logged_in_valid() {
+        let mut egs = EpicGames::new();
+        let mut ud = UserData::new();
+        ud.expires_at = Some(Utc::now() + Duration::hours(2));
+        egs.set_user_details(ud);
+        assert!(egs.is_logged_in());
+    }
+
+    #[test]
+    fn is_logged_in_within_600s_threshold() {
+        let mut egs = EpicGames::new();
+        let mut ud = UserData::new();
+        ud.expires_at = Some(Utc::now() + Duration::seconds(500));
+        egs.set_user_details(ud);
+        assert!(!egs.is_logged_in());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -298,8 +298,8 @@ impl EpicGames {
     /// Fetch catalog metadata for an asset (includes DLC tree).
     ///
     /// Returns `None` on API errors.
-    pub async fn asset_info(&mut self, asset: EpicAsset) -> Option<AssetInfo> {
-        match self.egs.asset_info(asset.clone()).await {
+    pub async fn asset_info(&mut self, asset: &EpicAsset) -> Option<AssetInfo> {
+        match self.egs.asset_info(asset).await {
             Ok(mut a) => a.remove(asset.catalog_item_id.as_str()),
             Err(_) => None,
         }
@@ -348,7 +348,7 @@ impl EpicGames {
     /// Fetch a JWT proving ownership of an asset.
     ///
     /// Returns `None` on API errors.
-    pub async fn ownership_token(&mut self, asset: EpicAsset) -> Option<String> {
+    pub async fn ownership_token(&mut self, asset: &EpicAsset) -> Option<String> {
         match self.egs.ownership_token(asset).await {
             Ok(a) => Some(a.token),
             Err(_) => None,

--- a/thoughts/ledgers/CONTINUITY_ses_3a18.md
+++ b/thoughts/ledgers/CONTINUITY_ses_3a18.md
@@ -1,0 +1,65 @@
+---
+session: ses_3a18
+updated: 2026-02-14T23:43:21.113Z
+---
+
+
+
+# Session Summary
+
+## Goal
+Decompose the monolithic `from_vec()` and `to_vec()` methods in `download_manifest.rs` into named section parsers/serializers (Item #6 from the improvement backlog), while keeping all 68 existing tests passing.
+
+## Constraints & Preferences
+- Non-breaking refactoring only — no public API changes
+- All 68 existing tests must continue to pass
+- Extracted functions should map to logical sections: header, meta, chunks, files, custom_fields
+- Parse helpers are free functions (take `&[u8]` + position); write helpers are methods on `DownloadManifest`
+
+## Progress
+### Done
+- [x] Items 1–5 (NOW) from improvement backlog all completed in prior sessions
+- [x] Item 10 (Default derive footgun) also done previously
+- [x] Extracted 5 parse free functions: `parse_header`, `parse_meta`, `parse_chunks`, `parse_files`, `parse_custom_fields` (lines ~138–465 of download_manifest.rs)
+- [x] Rewrote `from_vec()` to call the 5 parse helpers instead of inline logic
+- [x] Extracted 4 write methods: `write_meta`, `write_chunks`, `write_files`, `write_custom_fields` as methods on `DownloadManifest`
+- [x] Rewrote `to_vec()` to call the 4 write helpers (header/compression wrapping remains inline in `to_vec()`)
+- [x] Fixed duplicate `Some(res)` / `}` leftover from agent's partial work (lines 703-704)
+- [x] Build passes cleanly (`cargo build` — no errors, no warnings)
+- [x] All 68 tests pass (`cargo test`)
+
+### In Progress
+- [ ] Nothing actively in progress — Item #6 appears complete
+
+### Blocked
+- (none)
+
+## Key Decisions
+- **Parse helpers as free functions, write helpers as methods**: Parse functions take `(&[u8], &mut usize)` since they don't need `self`; write helpers are `&self` methods on `DownloadManifest` since they serialize from struct fields
+- **Header/compression logic stays in `from_vec()`/`to_vec()`**: The header parsing (magic bytes, decompression) and final compression/SHA wrapping are orchestration logic, not section-specific, so they remain inline as the "glue"
+- **Delegated to deep agent first, then manually fixed**: Agent created correct helper function bodies but left the file in an inconsistent state (old inline code still present, duplicate lines). Manual intervention wired everything together correctly.
+
+## Next Steps
+1. Verify the decomposition is clean — optionally review the extracted functions for any further cleanup
+2. Commit the changes
+3. Consider tackling remaining backlog items 7–9, 11–12:
+   - **#7**: Enrich `EpicAPIError` with source errors (breaking/semver)
+   - **#8**: Add `BinaryReader`/`BinaryWriter` abstraction (bounds-checked reads)
+   - **#9**: Add `Result`-returning `try_*` facade methods
+   - **#11**: Reduce `.clone()` usage
+   - **#12**: Add async integration tests (needs mock HTTP like `wiremock`)
+
+## Critical Context
+- The codebase is at commit `4978e2f` (prior to this session's changes)
+- All 68 tests pass after the decomposition
+- The parse helpers follow a consistent pattern: `fn parse_X(buffer: &[u8], position: &mut usize) -> Option<partial_fields>` returning tuples or structs of parsed values
+- The write helpers follow: `fn write_X(&self) -> Vec<u8>` returning serialized bytes for that section
+- `from_vec()` is now ~60 lines of orchestration; `to_vec()` is ~40 lines of orchestration + compression wrapping
+- The old `from_vec()` was ~390 lines inline; old `to_vec()` was ~320 lines inline
+
+## File Operations
+### Read
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/download_manifest.rs`
+
+### Modified
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/download_manifest.rs`

--- a/thoughts/ledgers/CONTINUITY_ses_3a1b.md
+++ b/thoughts/ledgers/CONTINUITY_ses_3a1b.md
@@ -1,0 +1,115 @@
+---
+session: ses_3a1b
+updated: 2026-02-14T23:12:05.583Z
+---
+
+# Session Summary
+
+## Goal
+Implement 14 missing Epic Games Store API endpoints in the `egs-api` Rust crate (discovered via MITM proxy dump comparison), then add documentation and examples for all new endpoints. All implementation and documentation is now complete.
+
+## Constraints & Preferences
+- Follow existing codebase patterns exactly: `EpicAPI` method in `src/api/*.rs` → response type in `src/api/types/*.rs` → facade wrapper in `src/lib.rs`
+- Use `serde` with `#[serde(rename_all = "camelCase")]` for deserialization
+- `#![deny(missing_docs)]` is active — every `pub` item must have `///` doc comments or build fails
+- Reuse existing types where possible (`ExternalAuth`, `AuthId` in `account.rs`, `AssetInfo` in `asset_info.rs`)
+- `EpicAPIError` enum in `src/api/error.rs` is the standard error type
+- HTTP helpers: `authorized_get_json`, `authorized_post_form_json`, `authorized_post_json` (new)
+- `autoexamples = false` in Cargo.toml — each example needs an `[[example]]` entry
+- MITM dump location: `~/epic-flows.mitm` (binary mitmproxy format)
+- Examples follow pattern: `common.rs` include, `login_or_restore`, sectioned API calls
+
+## Progress
+### Done
+- [x] Parsed MITM dump, identified 14 missing endpoints with full request/response shapes
+- [x] Created `authorized_post_json` helper in `src/api/mod.rs`
+- [x] Created 8 new type files in `src/api/types/`: `catalog_item.rs`, `catalog_offer.rs`, `currency.rs`, `price.rs`, `service_status.rs`, `presence.rs`, `billing_account.rs`, `quick_purchase.rs`
+- [x] Created 3 new API modules: `src/api/commerce.rs` (offer_prices, quick_purchase, billing_account), `src/api/status.rs` (service_status), `src/api/presence.rs` (update_presence)
+- [x] Extended `src/api/account.rs` with `external_auths()`, `sso_domains()`
+- [x] Extended `src/api/egs.rs` with `catalog_items()`, `catalog_offers()`, `bulk_catalog_items()`, `currencies()`, `library_state_token_status()`
+- [x] Extended `src/api/fab.rs` with `fab_file_download_info()`
+- [x] Added `start_client_credentials_session()` to `src/api/login.rs`
+- [x] Updated `src/api/types/mod.rs` to register all 8 new type modules
+- [x] Updated `src/api/mod.rs` to declare 3 new API modules
+- [x] Added 14 facade wrappers in `src/lib.rs` with enhanced `///` doc comments
+- [x] Created 5 new example files: `catalog.rs`, `commerce.rs`, `status.rs`, `presence.rs`, `client_credentials.rs`
+- [x] Extended 2 existing examples: `account.rs` (external_auths, sso_domains), `fab.rs` (fab_file_download_info)
+- [x] Registered 5 new `[[example]]` entries in `Cargo.toml`
+- [x] Updated `README.md` with examples section (12 total) and expanded API overview tables with 6 new categories
+- [x] Updated `src/lib.rs` module-level `//!` docs with new example names
+- [x] Build: ✅ `cargo build --lib` — 0 warnings
+- [x] Examples: ✅ `cargo build --examples` — all 14 examples compile
+- [x] Tests: ✅ 68/68 passed
+- [x] Docs: ✅ no warnings from our code (`cargo doc --no-deps`)
+
+### In Progress
+- (none — all tasks complete)
+
+### Blocked
+- (none)
+
+## Key Decisions
+- **Reuse `AssetInfo` for bulk catalog items**: MITM response shape matches existing `AssetInfo` struct, returns `HashMap<String, AssetInfo>`
+- **New `commerce.rs` module**: Price engine, quick purchase, and billing account are commerce-related
+- **New `status.rs` and `presence.rs` modules**: Clean separation of concerns
+- **Removed `authorized_patch_json` helper**: Presence endpoint returns 204 No Content (not JSON), so manual PATCH handling was correct
+- **`start_client_credentials_session` returns `UserData`**: Same as existing `start_session`, reuses the login token response type
+- **`ExternalAuth` field is `type_field`**: serde renames from JSON `type` to avoid Rust keyword collision
+- **Quick purchase example uses commented-out code**: Matches existing codebase convention for destructive operations (same pattern as `auth.rs` logout)
+
+## Next Steps
+1. Project is feature-complete — potential future work: integration tests with mock server, additional endpoint discovery from new MITM captures, publishing to crates.io
+
+## Critical Context
+- All 14 facade methods in `src/lib.rs`: `sso_domains()`, `external_auths()`, `currencies()`, `catalog_items()`, `catalog_offers()`, `bulk_catalog_items()`, `library_state_token_status()`, `service_status()`, `offer_prices()`, `quick_purchase()`, `update_presence()`, `fab_file_download_info()`, `billing_account()`, `auth_client_credentials()`
+- Key base URLs: `EPIC_LAUNCHER`, `EPIC_CATALOG`, `EPIC_ENTITLEMENT` defined in `src/api/mod.rs`
+- Running examples: `cargo run --example auth` (one-time login, saves token to `~/.egs-api/token.json`), then `cargo run --example <name>` reuses saved token
+- Known rustdoc 1.93 template bug produces `crates.js` error — unrelated to our code
+
+## File Operations
+### Read
+- `/mnt/disk2/stastny/repos/egs-api/Cargo.toml`
+- `/mnt/disk2/stastny/repos/egs-api/README.md`
+- `/mnt/disk2/stastny/repos/egs-api/examples` (directory listing)
+- `/mnt/disk2/stastny/repos/egs-api/examples/account.rs`
+- `/mnt/disk2/stastny/repos/egs-api/examples/fab.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/account.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/egs.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/error.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/fab.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/login.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/mod.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/presence.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types` (directory listing)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/account.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/mod.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/lib.rs`
+
+### Modified
+- `/mnt/disk2/stastny/repos/egs-api/Cargo.toml`
+- `/mnt/disk2/stastny/repos/egs-api/README.md`
+- `/mnt/disk2/stastny/repos/egs-api/examples/account.rs`
+- `/mnt/disk2/stastny/repos/egs-api/examples/catalog.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/examples/client_credentials.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/examples/commerce.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/examples/fab.rs`
+- `/mnt/disk2/stastny/repos/egs-api/examples/presence.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/examples/status.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/account.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/commerce.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/egs.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/fab.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/login.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/mod.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/presence.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/status.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/billing_account.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/catalog_item.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/catalog_offer.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/currency.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/mod.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/presence.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/price.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/quick_purchase.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/service_status.rs` (new)
+- `/mnt/disk2/stastny/repos/egs-api/src/lib.rs`

--- a/thoughts/ledgers/CONTINUITY_ses_3a22.md
+++ b/thoughts/ledgers/CONTINUITY_ses_3a22.md
@@ -1,0 +1,137 @@
+---
+session: ses_3a22
+updated: 2026-02-14T23:22:44.664Z
+---
+
+# Session Summary
+
+## Goal
+Improve the `egs-api` Rust crate with quality improvements (HTTP client reuse, helper extraction, bug fixes, unwrap removal, comprehensive tests, examples, documentation) and commit all changes to a `quality-improvements` branch with atomic, logical commits.
+
+## Constraints & Preferences
+- Project has `#![deny(missing_docs)]` — all `pub`/`pub(crate)` items MUST have doc comments or build fails
+- Rust edition 2018
+- No breaking public API changes
+- Commit style: ENGLISH + PLAIN (e.g., "Fix binary download manifest parsing", "Add friends") — no semantic prefixes
+- Token persistence in plaintext at `~/.egs-api/token.json` is acceptable
+- Task agent delegation does NOT work — must do everything directly
+- User has an upstream project that uses this crate
+
+## Progress
+### Done
+- [x] **HTTP helpers** extracted in `src/api/mod.rs`: `authorized_get_json<T>`, `authorized_post_form_json<T>`, `get_bytes`; inlined `build_client()`; manual `Default` impl
+- [x] **Refactored API callers**: `src/api/egs.rs`, `src/api/account.rs`, `src/api/fab.rs`, `src/api/login.rs` — all use HTTP helpers
+- [x] **Fixed bugs**: `to_vec()` in `download_manifest.rs` (chunk_sha_list unwrap + files.resize truncation), zlib/SHA unwraps in `chunk.rs`
+- [x] **Doc comments** on all public types and API methods across `src/api/types/*.rs`, `src/api/error.rs`, `src/api/mod.rs`, `src/lib.rs`
+- [x] **New API endpoints** from other session: `src/api/commerce.rs`, `src/api/presence.rs`, `src/api/status.rs` + types: `billing_account.rs`, `catalog_item.rs`, `catalog_offer.rs`, `currency.rs`, `presence.rs`, `price.rs`, `quick_purchase.rs`, `service_status.rs`
+- [x] **Test suite**: 10 → 68 tests across `utils.rs` (+9), `download_manifest.rs` (+12), `chunk.rs` (+4), `account.rs` (+6), `asset_info.rs` (+9), `fab_asset_manifest.rs` (+3), `error.rs` (+8), `lib.rs` (+7) — all passing
+- [x] **8+ examples** created: `common.rs`, `auth.rs`, `account.rs`, `entitlements.rs`, `library.rs`, `assets.rs`, `game_token.rs`, `fab.rs` + from other session: `catalog.rs`, `commerce.rs`, `client_credentials.rs`, `presence.rs`, `status.rs`
+- [x] **README.md** completely rewritten; **Cargo.toml** updated with metadata; **AGENTS.md** created with full project docs
+- [x] **All builds verified**: `cargo build --lib && cargo test && cargo build --examples` — 68 tests pass, 0 failures
+- [x] **Branch created**: `quality-improvements` from `master`
+
+### In Progress
+- [ ] **Committing changes** to `quality-improvements` branch — 8 planned atomic commits, NONE committed yet
+
+### Blocked
+- Task agent delegation does not work — all git operations must be done directly
+
+## Key Decisions
+- **8 atomic commits planned** in dependency order: (1) HTTP infrastructure → (2) API callers refactor → (3) bug fixes → (4) doc comments → (5) new API endpoints → (6) tests → (7) examples → (8) README/Cargo.toml/AGENTS.md
+- **Partial staging required**: Several files have changes spanning multiple commits (e.g., `src/lib.rs` has facade methods from commit 5 + tests from commit 6; `download_manifest.rs` has bug fixes from commit 3 + tests from commit 6; `error.rs` has docs from commit 4 + tests from commit 6)
+- **`fab_asset_manifest`** kept lower-level (special 403→FabTimeout handling doesn't fit generic helpers)
+- **`autoexamples = false`** in Cargo.toml to exclude `common.rs` from example auto-detection
+
+## Next Steps
+1. **Execute Commit 1**: `git add src/api/mod.rs && git commit -m "Reuse HTTP client and extract request helpers"`
+2. **Execute Commit 2**: `git add src/api/egs.rs src/api/account.rs src/api/fab.rs src/api/login.rs && git commit -m "Refactor API methods to use HTTP helpers"`
+3. **Execute Commit 3**: Stage ONLY bug-fix hunks from `src/api/types/download_manifest.rs` and `src/api/types/chunk.rs` (not test hunks) — `git commit -m "Fix to_vec() bugs and dangerous unwraps in manifest parsing"`
+4. **Execute Commit 4**: Stage doc-comment-only changes in `src/api/types/account.rs`, `asset_info.rs`, `asset_manifest.rs`, `entitlement.rs`, `epic_asset.rs`, `fab_asset_manifest.rs`, `friends.rs`, `library.rs`, `mod.rs`, `src/api/error.rs` (not test hunks) — `git commit -m "Add doc comments to all public types and API methods"`
+5. **Execute Commit 5**: Stage new files `src/api/commerce.rs`, `src/api/presence.rs`, `src/api/status.rs`, new type files (`billing_account.rs`, `catalog_item.rs`, `catalog_offer.rs`, `currency.rs`, `presence.rs`, `price.rs`, `quick_purchase.rs`, `service_status.rs`), and facade method hunks in `src/lib.rs` and `src/api/types/mod.rs` — `git commit -m "Add new API endpoints: catalog, commerce, status, presence"`
+6. **Execute Commit 6**: Stage remaining test hunks in `src/api/utils.rs`, `download_manifest.rs`, `chunk.rs`, `account.rs`, `asset_info.rs`, `fab_asset_manifest.rs`, `error.rs`, `src/lib.rs` — `git commit -m "Add comprehensive test suite (10 → 68 tests)"`
+7. **Execute Commit 7**: `git add examples/ && git commit -m "Add examples for all API endpoints"`
+8. **Execute Commit 8**: `git add README.md Cargo.toml AGENTS.md && git commit -m "Update README, Cargo.toml metadata, and crate-level docs"`
+9. **Verify** final state: `git log --oneline`, `cargo test`
+
+## Critical Context
+- **Branch**: `quality-improvements` (already created, currently on it, 0 commits ahead of master)
+- **Working directory**: `/mnt/disk2/stastny/repos/egs-api`
+- **Partial staging challenge**: Files like `src/lib.rs`, `download_manifest.rs`, `error.rs`, `account.rs`, `asset_info.rs`, `fab_asset_manifest.rs` contain changes from multiple logical concerns (docs + tests, or bugs + tests, or facade methods + tests). Need `git add -p` or careful hunk-based staging.
+- **Simpler approach alternative**: If partial staging proves too complex, could collapse into fewer commits (e.g., combine docs+tests, or combine bug fixes+docs+tests) — but user asked for atomic commits
+- **`cargo doc` has a known toolchain issue** (unrelated to our code) — ignore doc build errors
+- **Remaining improvement backlog** (not in scope for this branch): decompose `download_manifest.rs` (#6), enrich `EpicAPIError` with HTTP status/body (#7+#12)
+- **git status** showed: 21 modified files + 22 untracked files (excluding `.idea/`, `thoughts/`)
+
+## File Operations
+### Read
+- `/home/stastny/.local/share/opencode/tool-output/tool_c5e16e7cb001h3WKD7dejUqx22`
+- `/mnt/disk2/stastny/repos/egs-api/AGENTS.md`
+- `/mnt/disk2/stastny/repos/egs-api/Cargo.toml`
+- `/mnt/disk2/stastny/repos/egs-api/README.md`
+- `/mnt/disk2/stastny/repos/egs-api/examples` (directory listing)
+- `/mnt/disk2/stastny/repos/egs-api/examples/workflow.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/error.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/mod.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/account.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/asset_info.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/download_manifest.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/fab_asset_manifest.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/lib.rs`
+- `/mnt/disk2/stastny/repos/egs-api/thoughts/shared/plans/2026-02-14-api-quality-improvements.md`
+- `/mnt/disk2/stastny/repos/egs-api/thoughts/shared/designs/2026-02-14-api-quality-improvements-design.md`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/egs.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/account.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/fab.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/login.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/utils.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/mod.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/asset_manifest.rs`
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/chunk.rs`
+
+### Modified
+- `/mnt/disk2/stastny/repos/egs-api/AGENTS.md` — created with full project documentation
+- `/mnt/disk2/stastny/repos/egs-api/Cargo.toml` — keywords, categories, readme field, autoexamples, example entries
+- `/mnt/disk2/stastny/repos/egs-api/README.md` — complete rewrite
+- `/mnt/disk2/stastny/repos/egs-api/src/lib.rs` — crate-level docs, facade methods, tests
+- `/mnt/disk2/stastny/repos/egs-api/src/api/mod.rs` — HTTP helpers, inlined build_client, manual Default
+- `/mnt/disk2/stastny/repos/egs-api/src/api/egs.rs` — refactored to helpers
+- `/mnt/disk2/stastny/repos/egs-api/src/api/account.rs` — refactored to helpers
+- `/mnt/disk2/stastny/repos/egs-api/src/api/fab.rs` — partial refactor, fixed unwraps
+- `/mnt/disk2/stastny/repos/egs-api/src/api/login.rs` — uses self.client
+- `/mnt/disk2/stastny/repos/egs-api/src/api/commerce.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/presence.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/status.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/utils.rs` — test additions
+- `/mnt/disk2/stastny/repos/egs-api/src/api/error.rs` — doc comments + tests
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/mod.rs` — doc comments + new type re-exports
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/account.rs` — doc comments + tests
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/asset_info.rs` — doc comments + tests
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/asset_manifest.rs` — doc comments
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/download_manifest.rs` — bug fixes + tests
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/chunk.rs` — fixed unwraps + tests
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/entitlement.rs` — doc comments
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/epic_asset.rs` — doc comments
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/fab_asset_manifest.rs` — doc comments + tests
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/friends.rs` — doc comments
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/library.rs` — doc comments
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/billing_account.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/catalog_item.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/catalog_offer.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/currency.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/presence.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/price.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/quick_purchase.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/src/api/types/service_status.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/examples/common.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/auth.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/account.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/entitlements.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/library.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/assets.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/game_token.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/fab.rs` — new
+- `/mnt/disk2/stastny/repos/egs-api/examples/catalog.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/examples/commerce.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/examples/client_credentials.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/examples/presence.rs` — new (from other session)
+- `/mnt/disk2/stastny/repos/egs-api/examples/status.rs` — new (from other session)

--- a/thoughts/shared/designs/2026-02-14-api-quality-improvements-design.md
+++ b/thoughts/shared/designs/2026-02-14-api-quality-improvements-design.md
@@ -1,0 +1,170 @@
+---
+date: 2026-02-14
+topic: "egs-api quality improvements"
+status: validated
+---
+
+# egs-api Quality Improvements Design
+
+## Problem Statement
+
+The egs-api library has accumulated technical debt across HTTP handling, error management, and binary manifest parsing. Key issues: ~200 lines of duplicated HTTP boilerplate, panics in a library crate (unwrap on URLs, missing fields, truncated buffers), HTTP client rebuilt per-request defeating connection pooling, and a 1059-line monolithic manifest parser.
+
+## Constraints
+
+- **No semver-breaking changes in items 1-5** — this is a published crate (v0.8.1)
+- **Edition 2018** — no 2021+ features
+- **Must pass existing CI** — `cargo build --lib && cargo test --tests --lib`
+- **`#![deny(missing_docs)]`** — all new public items need doc comments
+- **`#![cfg_attr(test, deny(warnings))]`** — zero warnings in tests
+
+## Improvements Overview
+
+### NOW — Items 1-5 (High impact, non-breaking, execute immediately)
+
+| # | Improvement | What Changes |
+|---|------------|--------------|
+| 1 | Extract HTTP helper methods | New `send_get_json<T>()`, `send_post_json<T>()`, `send_get_bytes()` internal methods on `EpicAPI` in `mod.rs` |
+| 2 | Reuse `self.client` | `authorized_get_client`/`authorized_post_client` stop calling `build_client()`, use `self.client` instead |
+| 3 | Fix `to_vec()` panic on `chunk_sha_list: None` | Handle `None` case with empty iteration instead of `unwrap()` |
+| 4 | Fix `files.resize()` bug in `to_vec()` | Replace `files.resize()` with correct flag byte appending |
+| 5 | Replace `unwrap()` with `?` on URLs + parsing | Convert panicking unwraps to `Result` propagation in internal methods |
+
+### LATER — Items 6-12 (Medium/low impact or breaking)
+
+| # | Improvement | What Changes |
+|---|------------|--------------|
+| 6 | Decompose `from_vec()`/`to_vec()` | Split into `parse_header/meta/chunks/files/custom_fields` functions |
+| 7 | Enrich `EpicAPIError` with source errors | Add `NetworkError(reqwest::Error)`, `DeserializationError(String)`, `HttpError { status, body }` variants |
+| 8 | Add `BinaryReader`/`BinaryWriter` abstraction | New internal structs wrapping `&[u8]` / `Vec<u8>` with bounds-checked reads |
+| 9 | Add `Result`-returning facade methods | New `try_*` methods on `EpicGames` alongside existing `Option`-returning ones |
+| 10 | Fix `Default` derive footgun | Implement `Default` manually for `EpicAPI` to call `new()`, or remove derive |
+| 11 | Reduce `.clone()` usage | Change API methods to take `&EpicAsset` instead of owned, iterate by reference in hot paths |
+| 12 | Add manifest parsing tests | Unit tests for `from_vec()` and `to_vec()` with sample binary/JSON data |
+
+---
+
+## Detailed Design — Items 1-5
+
+### Item 1: Extract HTTP Helper Methods
+
+**Location:** `src/api/mod.rs`
+
+**New internal methods on `EpicAPI`:**
+
+- `async fn send_get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T, EpicAPIError>` — builds authorized GET, sends, checks status, parses JSON, maps errors
+- `async fn send_post_json<T: DeserializeOwned, B: Serialize>(&self, url: &str, body: &B) -> Result<T, EpicAPIError>` — same for POST with JSON body
+- `async fn send_post_form<T: DeserializeOwned>(&self, url: &str, form: &[(&str, String)]) -> Result<T, EpicAPIError>` — POST with form encoding (for ownership_token)
+- `async fn send_get_bytes(&self, url: &str) -> Result<Vec<u8>, EpicAPIError>` — for manifest binary downloads
+
+**Error mapping inside helpers:**
+- URL parse failure → `EpicAPIError::InvalidParams`
+- Network error → `EpicAPIError::Unknown` (logged with `error!`)
+- Non-200 status → `EpicAPIError::Unknown` (logged with `warn!`, body logged)
+- 403 status → check if Fab context, map to `FabTimeout` where appropriate
+- JSON parse error → `EpicAPIError::Unknown` (logged with `error!`)
+
+**Then refactor callers:** `egs.rs`, `account.rs`, `fab.rs` methods become 2-5 line functions that build a URL and call the helper. `login.rs` keeps its own flow (basic_auth, form params, special response handling).
+
+**Special cases:**
+- `fab_asset_manifest` needs 403→`FabTimeout` mapping — add an optional status-code hook or handle it at the call site after the helper
+- `asset_download_manifests` fetches without auth — add `send_get_bytes_unauth()` or use `self.client` directly
+- `library_items` / `fab_library_items` have pagination loops — they call the helper repeatedly, loop logic stays in the method
+
+### Item 2: Reuse `self.client`
+
+**Location:** `src/api/mod.rs`
+
+**Change `authorized_get_client` and `authorized_post_client`:**
+- Remove: `let client = EpicAPI::build_client().build().unwrap();`
+- Replace with: `self.client.get(url)` / `self.client.post(url)`
+- Keep: `self.set_authorization_header(...)` call
+
+**Change unauthenticated requests** in `egs.rs::asset_download_manifests`, `fab.rs::fab_download_manifest`, `login.rs::invalidate_sesion`:
+- Remove: `let client = EpicAPI::build_client().build().unwrap();`
+- Replace with: `self.client.get(url)` / `self.client.delete(url)` (without auth header)
+
+**Benefit:** Connection pooling works, cookies persist across requests (important for session), fewer allocations.
+
+**Risk:** If any endpoint relied on fresh cookie state — unlikely and undesirable. Test login + subsequent API calls.
+
+### Item 3: Fix `to_vec()` Panic on `chunk_sha_list: None`
+
+**Location:** `src/api/types/download_manifest.rs`, in `to_vec()` method
+
+**Current code (panics):**
+```
+for sha in self.chunk_sha_list.as_ref().unwrap().values() {
+```
+
+**Fix:** Handle `None` by writing zero-filled SHA entries:
+```
+match &self.chunk_sha_list {
+    Some(sha_list) => { iterate sha_list.values(), decode_hex and append }
+    None => { for each chunk in chunk_hash_list.keys(), append 20 zero bytes }
+}
+```
+
+### Item 4: Fix `files.resize()` Bug in `to_vec()`
+
+**Location:** `src/api/types/download_manifest.rs`, in `to_vec()` method
+
+**Current code (likely truncates):**
+```
+// flags
+// TODO: Figure out what Epic puts in theirs
+files.resize(self.file_manifest_list.len(), 0);
+```
+
+This resizes the entire `files` Vec to `file_manifest_list.len()` — which is almost certainly smaller than its current size (it already has filenames, symlinks, hashes). This **truncates** the buffer.
+
+**Fix:** Append one zero byte per file for the flags field:
+```
+for _ in &self.file_manifest_list {
+    files.push(0u8);
+}
+```
+
+### Item 5: Replace `unwrap()` with Error Propagation
+
+**Locations and fixes:**
+
+1. **`src/api/mod.rs` — `authorized_get_client` / `authorized_post_client`:**
+   - `Url::parse(&url).unwrap()` → callers should pass `&str`, helpers parse with `?`
+
+2. **`src/api/egs.rs`:**
+   - `Url::parse(&url).unwrap()` in `assets`, `asset_manifest`, `asset_info`, `game_token`, `ownership_token` → use `?` with mapping to `InvalidParams`
+   - `response.text().await.unwrap()` in warn branches → use `.unwrap_or_default()` or `match`
+
+3. **`src/api/account.rs`:**
+   - Same `Url::parse().unwrap()` and `response.text().await.unwrap()` patterns
+
+4. **`src/api/fab.rs`:**
+   - Same patterns
+   - `response.text().await.unwrap()` on OK path in `fab_asset_manifest`
+
+5. **`src/api/login.rs`:**
+   - `self.user_data.refresh_token.clone().unwrap()` in `start_session` → return `Err(EpicAPIError::InvalidCredentials)` if refresh token is `None`
+   - `Url::from_str(&url).unwrap()` in `invalidate_sesion`
+
+6. **`src/api/types/download_manifest.rs`:**
+   - `z.read_to_end(&mut data).unwrap()` → return `None`
+   - `buffer[position]` direct accesses → bounds check (or defer to item 8)
+   - `Url::parse()` in `download_links()` → return `None` for invalid URLs
+
+**Strategy:** Since internal methods already return `Result<T, EpicAPIError>`, most `unwrap()` calls can be replaced with `?` after mapping the error. For `download_manifest.rs` where the return type is `Option`, use `.ok()?` or early return `None`.
+
+Note: Item 5 for `download_manifest.rs` should focus on the **most dangerous panics** only (URL parsing, zlib decompression, missing chunk_sha_list). The comprehensive bounds-checking refactor is deferred to items 6+8.
+
+---
+
+## Testing Strategy
+
+- **All items:** Must pass `cargo build --lib && cargo test --tests --lib`
+- **Items 1-2:** Behavioral — same API surface, same results. Existing tests + manual verification.
+- **Items 3-4:** Bug fixes — ideally add a test that exercises `to_vec()` on a JSON-parsed manifest (chunk_sha_list: None) and verifies output isn't truncated. But existing test infrastructure is minimal, so at minimum verify `cargo test` passes.
+- **Item 5:** Each replaced `unwrap()` should handle the error gracefully instead of panicking.
+
+## Open Questions
+
+None — items 1-5 are straightforward and non-breaking. Items 6-12 have design decisions (e.g., error enum variants, whether to split files) that can be resolved when they're picked up.

--- a/thoughts/shared/plans/2026-02-14-api-quality-improvements.md
+++ b/thoughts/shared/plans/2026-02-14-api-quality-improvements.md
@@ -1,0 +1,376 @@
+---
+date: 2026-02-14
+design: thoughts/shared/designs/2026-02-14-api-quality-improvements-design.md
+scope: "Items 1-5 only"
+status: ready
+---
+
+# Implementation Plan: egs-api Quality Improvements (Items 1-5)
+
+## Constraints Reminder
+
+- No semver-breaking changes
+- Edition 2018
+- `#![deny(missing_docs)]` — doc comments on all new pub items
+- `#![cfg_attr(test, deny(warnings))]` — zero warnings
+- Must pass: `cargo build --lib && cargo test --tests --lib`
+
+## Execution Order
+
+Items ordered for minimal churn — each step builds on the previous.
+
+---
+
+## Step 1: Reuse `self.client` (Item 2)
+
+**Files:** `src/api/mod.rs`
+
+### 1a. Fix `authorized_get_client`
+
+Change from:
+```rust
+fn authorized_get_client(&self, url: Url) -> RequestBuilder {
+    let client = EpicAPI::build_client().build().unwrap();
+    self.set_authorization_header(client.get(url))
+}
+```
+
+To:
+```rust
+fn authorized_get_client(&self, url: Url) -> RequestBuilder {
+    self.set_authorization_header(self.client.get(url))
+}
+```
+
+### 1b. Fix `authorized_post_client`
+
+Same pattern — replace `EpicAPI::build_client().build().unwrap()` with `self.client`.
+
+### 1c. Fix unauthenticated requests
+
+In these locations, replace `let client = EpicAPI::build_client().build().unwrap();` with `self.client`:
+
+- `src/api/egs.rs` → `asset_download_manifests` method: `let client = EpicAPI::build_client().build().unwrap();` → `self.client` (note: this method takes `&self` so this works)
+- `src/api/fab.rs` → `fab_download_manifest` method: same change
+- `src/api/login.rs` → `invalidate_sesion` method: same change
+
+### Verify
+
+```bash
+cargo build --lib && cargo test --tests --lib
+```
+
+---
+
+## Step 2: Extract HTTP Helper Methods (Item 1)
+
+**Files:** `src/api/mod.rs` (new methods), then `src/api/egs.rs`, `src/api/account.rs`, `src/api/fab.rs` (refactor callers)
+
+### 2a. Add helper methods to `EpicAPI` in `src/api/mod.rs`
+
+Add these internal helper methods inside the `impl EpicAPI` block:
+
+**`authorized_get_json`** — Authorized GET that returns deserialized JSON:
+- Signature: `pub(crate) async fn authorized_get_json<T: serde::de::DeserializeOwned>(&self, url: &str) -> Result<T, EpicAPIError>`
+- Implementation:
+  1. Parse URL with `Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?`
+  2. `self.authorized_get_client(parsed_url).send().await` — map Err to `EpicAPIError::Unknown` with `error!` log
+  3. Check `response.status() == StatusCode::OK` — if not, `warn!` log status + body (using `.text().await.unwrap_or_default()`), return `Err(EpicAPIError::Unknown)`
+  4. `response.json::<T>().await` — map Err to `EpicAPIError::Unknown` with `error!` log
+  5. Return `Ok(result)`
+
+**`authorized_post_json`** — Authorized POST with JSON body:
+- Signature: `pub(crate) async fn authorized_post_json<T: serde::de::DeserializeOwned>(&self, url: &str, body: &impl serde::Serialize) -> Result<T, EpicAPIError>`
+- Same pattern as above but uses `authorized_post_client` and `.json(body)`
+
+**`authorized_post_form`** — Authorized POST with form body:
+- Signature: `pub(crate) async fn authorized_post_form<T: serde::de::DeserializeOwned>(&self, url: &str, form: &[(String, String)]) -> Result<T, EpicAPIError>`
+- Same but uses `.form(form)`
+
+**`get_bytes`** — Unauthenticated GET returning raw bytes:
+- Signature: `pub(crate) async fn get_bytes(&self, url: &str) -> Result<Vec<u8>, EpicAPIError>`
+- Uses `self.client.get(...)` (no auth header)
+- Returns `response.bytes().await` as `Vec<u8>`
+
+Add necessary imports at top of `mod.rs`: `use serde::de::DeserializeOwned;`
+
+### 2b. Refactor `src/api/egs.rs`
+
+Replace boilerplate in each method:
+
+**`assets`** — Replace the entire match block with:
+```rust
+let url = format!("https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/{}?label={}", plat, lab);
+self.authorized_get_json(&url).await
+```
+
+**`asset_manifest`** — After param validation and URL building:
+```rust
+let mut manifest: AssetManifest = self.authorized_get_json(&url).await?;
+manifest.platform = platform;
+// ... set other fields
+Ok(manifest)
+```
+
+**`asset_info`** — One-liner after URL building:
+```rust
+self.authorized_get_json(&url).await
+```
+
+**`game_token`** — One-liner:
+```rust
+self.authorized_get_json(&url).await
+```
+
+**`ownership_token`** — Uses POST with form, replace with:
+```rust
+self.authorized_post_form(&url, &form_params).await
+```
+
+**`asset_download_manifests`** — The inner manifest fetch loop: replace `let client = ...` block with:
+```rust
+match self.get_bytes(&url).await {
+    Ok(data) => match DownloadManifest::parse(data.to_vec()) { ... }
+    Err(e) => { error!("{:?}", e); }
+}
+```
+Note: The outer loop logic and custom field setting stays — only the HTTP call changes.
+
+**`library_items`** — The inner fetch in the pagination loop: replace with:
+```rust
+match self.authorized_get_json::<Library>(&url).await {
+    Ok(mut records) => { ... pagination logic ... }
+    Err(e) => { error!("{:?}", e); break; }
+}
+```
+
+### 2c. Refactor `src/api/account.rs`
+
+**`account_details`** — Replace with:
+```rust
+self.authorized_get_json(&url).await
+```
+
+**`account_ids_details`** — Build URL with query params, then:
+```rust
+self.authorized_get_json(parsed_url.as_str()).await
+```
+
+**`account_friends`** — One-liner after URL building:
+```rust
+self.authorized_get_json(&url).await
+```
+
+**`user_entitlements`** — One-liner after URL building:
+```rust
+self.authorized_get_json(&url).await
+```
+
+### 2d. Refactor `src/api/fab.rs`
+
+**`fab_asset_manifest`** — This one has special 403 handling. Two options:
+- Option A: Don't use the helper, keep custom handling but simplify it
+- Option B: Use `authorized_post_json` but handle 403 at the call site
+
+Recommended: Option A — keep the method mostly as-is but use `self.client` (already done in step 1) and simplify the inner match. The 403→FabTimeout mapping is unique enough to warrant its own handling. Just clean up the nested matches and remove redundant `build_client()`.
+
+**`fab_download_manifest`** — Replace inner HTTP call with `self.get_bytes(&point.manifest_url)`:
+```rust
+match self.get_bytes(&point.manifest_url).await {
+    Ok(data) => match DownloadManifest::parse(data.to_vec()) {
+        None => Err(EpicAPIError::Unknown),
+        Some(man) => Ok(man),
+    },
+    Err(e) => Err(e),
+}
+```
+
+**`fab_library_items`** — Pagination loop inner fetch: use `authorized_get_json` similar to `library_items`.
+
+### Verify
+
+```bash
+cargo build --lib && cargo test --tests --lib
+```
+
+---
+
+## Step 3: Fix `to_vec()` Bugs (Items 3 + 4)
+
+**File:** `src/api/types/download_manifest.rs`
+
+### 3a. Fix `chunk_sha_list.unwrap()` panic (Item 3)
+
+Find in `to_vec()`:
+```rust
+for sha in self.chunk_sha_list.as_ref().unwrap().values() {
+```
+
+Replace with:
+```rust
+match &self.chunk_sha_list {
+    Some(sha_list) => {
+        for sha in sha_list.values() {
+            match crate::api::utils::decode_hex(sha.as_str()) {
+                Ok(mut s) => chunks.append(s.borrow_mut()),
+                Err(_) => chunks.append(vec![0u8; 20].borrow_mut()),
+            }
+        }
+    }
+    None => {
+        for _ in self.chunk_hash_list.keys() {
+            chunks.append(vec![0u8; 20].borrow_mut());
+        }
+    }
+}
+```
+
+### 3b. Fix `files.resize()` bug (Item 4)
+
+Find in `to_vec()`:
+```rust
+// flags
+// TODO: Figure out what Epic puts in theirs
+files.resize(self.file_manifest_list.len(), 0);
+```
+
+Replace with:
+```rust
+// flags — one byte per file (currently zero/unknown)
+// TODO: Figure out what Epic puts in theirs
+for _ in &self.file_manifest_list {
+    files.push(0u8);
+}
+```
+
+### Verify
+
+```bash
+cargo build --lib && cargo test --tests --lib
+```
+
+---
+
+## Step 4: Replace Dangerous `unwrap()` Calls (Item 5)
+
+**Files:** Multiple — sweep across the codebase
+
+### 4a. `src/api/login.rs` — refresh_token panic
+
+Find in `start_session`:
+```rust
+None => [
+    ("grant_type".to_string(), "refresh_token".to_string()),
+    (
+        "refresh_token".to_string(),
+        self.user_data.refresh_token.clone().unwrap(),
+    ),
+    ("token_type".to_string(), "eg1".to_string()),
+],
+```
+
+Replace with:
+```rust
+None => {
+    let refresh = match &self.user_data.refresh_token {
+        Some(t) => t.clone(),
+        None => return Err(EpicAPIError::InvalidCredentials),
+    };
+    [
+        ("grant_type".to_string(), "refresh_token".to_string()),
+        ("refresh_token".to_string(), refresh),
+        ("token_type".to_string(), "eg1".to_string()),
+    ]
+}
+```
+
+### 4b. `src/api/login.rs` — URL parsing in `invalidate_sesion`
+
+Find:
+```rust
+match client.delete(Url::from_str(&url).unwrap()).send().await {
+```
+
+Replace (now using self.client from step 1):
+```rust
+let parsed_url = match Url::from_str(&url) {
+    Ok(u) => u,
+    Err(_) => return false,
+};
+match self.client.delete(parsed_url).send().await {
+```
+
+### 4c. `src/api/egs.rs` — `response.text().await.unwrap()` in warn branches
+
+These are in the non-OK status branches. After step 2, most of these will be inside the helper methods already. But for any remaining (like `asset_download_manifests` loop), replace:
+```rust
+response.text().await.unwrap()
+```
+with:
+```rust
+response.text().await.unwrap_or_default()
+```
+
+### 4d. `src/api/fab.rs` — `response.text().await.unwrap()` calls
+
+Same treatment — replace `.unwrap()` with `.unwrap_or_default()` in warn/error logging branches.
+
+### 4e. `src/api/types/download_manifest.rs` — critical panics only
+
+Focus on the most dangerous ones (comprehensive bounds-checking deferred to item 8):
+
+1. **`download_links()` URL parsing:**
+   Find: `Url::parse(&format!(...)).unwrap()`
+   Replace: Use `Url::parse(...).ok()?` or skip the entry with `continue`
+
+2. **`from_vec()` zlib decompression:**
+   Find: `z.read_to_end(&mut data).unwrap();`
+   Replace:
+   ```rust
+   if z.read_to_end(&mut data).is_err() {
+       error!("Failed to decompress manifest data");
+       return None;
+   }
+   ```
+
+3. **`to_vec()` chunk GUID encoding:**
+   Find: `.collect::<Result<Vec<&str>, _>>().unwrap()` and `u32::from_str_radix(g, 16).unwrap()`
+   Replace with graceful fallback — if GUID is malformed, use 0:
+   ```rust
+   let subs: Vec<&str> = match chunk.as_bytes().chunks(8).map(std::str::from_utf8).collect::<Result<Vec<&str>, _>>() {
+       Ok(s) => s,
+       Err(_) => { continue; }
+   };
+   for g in subs {
+       chunks.extend_from_slice(&u32::from_str_radix(g, 16).unwrap_or(0).to_le_bytes());
+   }
+   ```
+
+### Verify
+
+```bash
+cargo build --lib && cargo test --tests --lib
+```
+
+---
+
+## Final Verification
+
+After all steps:
+
+```bash
+cargo build --lib && cargo test --tests --lib
+```
+
+Ensure no new warnings (denied in test mode).
+
+## Files Modified Summary
+
+| File | Steps |
+|------|-------|
+| `src/api/mod.rs` | 1a, 1b, 2a |
+| `src/api/egs.rs` | 1c, 2b, 4c |
+| `src/api/account.rs` | 2c |
+| `src/api/fab.rs` | 1c, 2d, 4d |
+| `src/api/login.rs` | 1c, 4a, 4b |
+| `src/api/types/download_manifest.rs` | 3a, 3b, 4e |


### PR DESCRIPTION
## v0.9.0 — Quality improvements, new API endpoints, and breaking error changes

Major quality overhaul of the egs-api crate covering HTTP infrastructure, error handling, binary manifest parsing, 14 new API endpoints, and comprehensive test/doc coverage.

### Breaking Changes

- **`EpicAPIError::Unknown` removed** — replaced by `NetworkError(reqwest::Error)`, `DeserializationError(String)`, and `HttpError { status, body }` to preserve error context for callers
- **`DownloadManifest::from_vec`** now takes `&[u8]` instead of `Vec<u8>`
- **`DownloadManifest::set_custom_field`** now takes `(&str, &str)` instead of `(String, String)`
- **`EpicGames::asset_info` / `ownership_token`** now take `&EpicAsset` instead of `EpicAsset`
- **`UserData::access_token` / `refresh_token`** now return `Option<&str>` instead of `Option<String>`

See `CHANGELOG.md` for the full migration guide.

### Added

- 14 new API endpoints: catalog, commerce, status, presence, external auths, SSO, client credentials, and more
- `try_*` facade methods that return `Result` instead of `Option` for error visibility
- `BinaryReader` / `BinaryWriter` — bounds-checked binary I/O for manifest parsing
- 13 new examples covering all endpoints
- Test suite expanded from 10 to 87 tests
- Doc comments on all public types and API methods
- `CHANGELOG.md`

### Fixed

- `to_vec()` panic when `chunk_sha_list` is `None`
- `to_vec()` buffer truncation from incorrect `files.resize()`
- Dangerous `unwrap()` calls across manifest parsing and zlib decompression
- HTTP client now reused across requests (was rebuilt per-request)

### Infrastructure

- Rust edition 2018 → 2021
- `reqwest` `blocking` feature moved to dev-dependencies (consumers no longer pull it in)
- Added `rust-version = "1.82"` (MSRV)
- Expanded crates.io categories (`api-bindings`, `games`) and keywords
- Internal HTTP boilerplate extracted into shared helpers
- `download_manifest.rs` decomposed into named section parsers
- Reduced `.clone()` usage crate-wide
