### PR TITLE
Bump to 0.10.0: cloud saves, Uplay integration, artifact service, SID…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-02-15
+
+### Added
+
+- **Cloud Saves API** — `cloud_save_list`, `cloud_save_query`,
+  `cloud_save_delete` for managing Epic cloud save files.
+- **Uplay / Store Integration** — `store_get_uplay_codes`,
+  `store_claim_uplay_code`, `store_redeem_uplay_codes` for querying and
+  redeeming Ubisoft activation codes via Epic's GraphQL store API.
+- **Artifact Service** — `artifact_service_ticket` and
+  `game_manifest_by_ticket` for the two-step artifact service download flow.
+- **Launcher Manifests** — `launcher_manifests` for fetching launcher asset
+  manifests.
+- **Delta Manifests** — `delta_manifest` for fetching patch manifests between
+  two builds.
+- **SID Authentication** — `auth_sid` for authenticating via SID cookie
+  (multi-step web-based exchange code flow).
+- New type modules: `cloud_save`, `artifact_service`, `exchange_code`, `uplay`.
+- New `store` API module for GraphQL-based store operations.
+- New examples: `cloud_saves`, `uplay`.
+- Updated `assets` example with artifact service, launcher manifest, and delta
+  manifest sections.
+- Updated `auth` example with SID authentication alternative flow.
+- Updated README with new API sections, examples, and architecture diagram.
+
+### Fixed
+
+- **Entitlement pagination** — replaced single `count=5000` request with
+  proper pagination loop using `count=1000`, stopping when batch is smaller
+  than page size (matches legendary's behavior).
+- Removed dead `read_le_64_signed` function (superseded by
+  `BinaryReader::read_i64`), eliminating the last compiler warning.
+
 ## [0.9.0] - 2026-02-15
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egs-api"
-version = "0.9.0"
+version = "0.10.0"
 authors = ["Milan Šťastný <milan@acheta.games>"]
 description = "Interface to the Epic Games API"
 categories = ["api-bindings", "asynchronous", "games"]
@@ -92,3 +92,11 @@ path = "examples/presence.rs"
 [[example]]
 name = "client_credentials"
 path = "examples/client_credentials.rs"
+
+[[example]]
+name = "cloud_saves"
+path = "examples/cloud_saves.rs"
+
+[[example]]
+name = "uplay"
+path = "examples/uplay.rs"

--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ Built on `reqwest` / `tokio`.
 - **Entitlements** — Query all user entitlements (games, DLC, subscriptions).
 - **Library** — Paginated library listing with optional metadata.
 - **Tokens** — Game exchange tokens and per-asset ownership tokens (JWT).
+- **Cloud Saves** — List, query, and delete cloud save files.
+- **Uplay Integration** — Query and redeem Ubisoft activation codes via
+  Epic's GraphQL store API.
 
 ## Quick Start
 
@@ -113,6 +116,8 @@ cargo run --example commerce             # Currencies, prices, billing, quick pu
 cargo run --example status               # Service status (lightswitch API)
 cargo run --example presence             # Update online presence
 cargo run --example client_credentials   # App-level auth + library state tokens
+cargo run --example cloud_saves          # Cloud save file listing + management
+cargo run --example uplay                # Ubisoft activation code queries
 ```
 
 ## API Overview
@@ -128,6 +133,7 @@ distinctions.
 | Method | Description |
 |--------|-------------|
 | `auth_code(exchange_token, authorization_code)` | Start a new session |
+| `auth_sid(sid)` | Authenticate via SID cookie (web-based exchange code flow) |
 | `auth_client_credentials()` | App-level auth (no user context) |
 | `login()` | Resume session using saved refresh token |
 | `logout()` | Invalidate current session |
@@ -149,6 +155,26 @@ distinctions.
 | `game_token()` | Short-lived exchange code for game launches |
 | `ownership_token(asset)` | JWT proving asset ownership |
 | `library_state_token_status(token_id)` | Check library state token validity |
+| `artifact_service_ticket(platform, label, namespace, item_id, app)` | Artifact service download ticket |
+| `game_manifest_by_ticket(platform, label, namespace, item_id, app, ticket)` | Game manifest via artifact service ticket |
+| `launcher_manifests(platform, label, namespace, item_id, app)` | Launcher asset manifests |
+| `delta_manifest(manifest, old_build_id, new_build_id)` | Delta/patch manifest between two builds |
+
+### Cloud Saves
+
+| Method | Description |
+|--------|-------------|
+| `cloud_save_list()` | List all cloud save files for the current user |
+| `cloud_save_query(filename)` | Query metadata for a specific cloud save file |
+| `cloud_save_delete(filename)` | Delete a cloud save file |
+
+### Uplay / Store Integration
+
+| Method | Description |
+|--------|-------------|
+| `store_get_uplay_codes(namespace, offer_id)` | Query Ubisoft activation codes for a game |
+| `store_claim_uplay_code(namespace, offer_id)` | Claim a Ubisoft activation code |
+| `store_redeem_uplay_codes(uplay_codes)` | Redeem Ubisoft activation codes |
 
 ### Fab Marketplace
 
@@ -214,9 +240,10 @@ via `custom_field(key)`.
 EpicGames (public facade, src/lib.rs)
   └── EpicAPI (internal, src/api/mod.rs)
         ├── login.rs    — OAuth: start, resume, invalidate
-        ├── egs.rs      — Assets, manifests, library, tokens
+        ├── egs.rs      — Assets, manifests, library, cloud saves, tokens
         ├── account.rs  — Account details, friends, entitlements
-        └── fab.rs      — Fab marketplace integration
+        ├── fab.rs      — Fab marketplace integration
+        └── store.rs    — Uplay/Ubisoft code redemption (GraphQL)
 ```
 
 `EpicGames` is the consumer-facing struct. It delegates to `EpicAPI` which

--- a/examples/assets.rs
+++ b/examples/assets.rs
@@ -76,4 +76,61 @@ async fn main() {
             test_asset.app_name
         ),
     }
+
+    println!("\n=== Artifact Service Ticket ===\n");
+
+    match egs
+        .artifact_service_ticket(&test_asset.namespace, &test_asset.app_name, None, None)
+        .await
+    {
+        Ok(ticket) => {
+            println!(
+                "Ticket expires in: {} seconds",
+                ticket.expires_in_seconds.unwrap_or(0)
+            );
+            if let Some(signed) = &ticket.signed_ticket {
+                println!(
+                    "Signed ticket (first 80 chars): {}...",
+                    &signed[..signed.len().min(80)]
+                );
+
+                println!("\n=== Game Manifest by Ticket ===\n");
+
+                match egs
+                    .game_manifest_by_ticket(&test_asset.app_name, signed, None, None)
+                    .await
+                {
+                    Ok(m) => println!("Manifest elements: {}", m.elements.len()),
+                    Err(e) => eprintln!("Failed to fetch manifest by ticket: {:?}", e),
+                }
+            }
+        }
+        Err(e) => eprintln!("Failed to get artifact service ticket: {:?}", e),
+    }
+
+    println!("\n=== Launcher Manifests ===\n");
+
+    match egs.launcher_manifests(None, None).await {
+        Ok(m) => {
+            println!("Launcher manifest elements: {}", m.elements.len());
+            for elem in &m.elements {
+                for manifest in &elem.manifests {
+                    println!("  URI: {}", manifest.uri);
+                }
+            }
+        }
+        Err(e) => eprintln!("Failed to fetch launcher manifests: {:?}", e),
+    }
+
+    println!("\n=== Delta Manifest ===\n");
+
+    println!("Delta manifests require two different build IDs.");
+    println!("Trying with dummy IDs to demonstrate the API (expected to return None):");
+    match egs
+        .delta_manifest("https://example.com", "old-build", "new-build")
+        .await
+    {
+        Some(data) => println!("Got delta manifest: {} bytes", data.len()),
+        None => println!("No delta manifest available (expected for most assets)."),
+    }
 }

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -2,6 +2,7 @@
 mod common;
 
 use egs_api::EpicGames;
+use std::io;
 
 #[tokio::main]
 async fn main() {
@@ -10,7 +11,30 @@ async fn main() {
 
     println!("=== Authentication Example ===\n");
 
-    if !common::login_or_restore(&mut egs).await {
+    let args: Vec<String> = std::env::args().collect();
+    let use_sid = args.iter().any(|a| a == "--sid");
+
+    if use_sid {
+        println!("SID auth mode. Enter your Epic session ID (SID):");
+        let mut sid = String::new();
+        io::stdin().read_line(&mut sid).unwrap();
+        let sid = sid.trim();
+
+        match egs.auth_sid(sid).await {
+            Ok(true) => {
+                println!("SID auth succeeded!");
+                common::save_token(&egs);
+            }
+            Ok(false) => {
+                eprintln!("SID auth returned false");
+                std::process::exit(1);
+            }
+            Err(e) => {
+                eprintln!("SID auth failed: {:?}", e);
+                std::process::exit(1);
+            }
+        }
+    } else if !common::login_or_restore(&mut egs).await {
         eprintln!("Authentication failed");
         std::process::exit(1);
     }
@@ -20,11 +44,5 @@ async fn main() {
     println!("Account ID: {}", details.account_id.unwrap_or_default());
 
     println!("\nToken saved. Run other examples without re-authenticating.");
-    println!("To logout, uncomment the logout section below.\n");
-
-    // Uncomment to invalidate the session and delete the saved token:
-    // if egs.logout().await {
-    //     println!("Logged out successfully");
-    //     let _ = std::fs::remove_file(dirs_or_home().join(".egs-api/token.json"));
-    // }
+    println!("Tip: use --sid flag to authenticate via session ID instead.\n");
 }

--- a/examples/cloud_saves.rs
+++ b/examples/cloud_saves.rs
@@ -1,0 +1,91 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Cloud Save List (all games) ===\n");
+
+    match egs.cloud_save_list(None, false).await {
+        Ok(response) => {
+            println!("Total cloud save files: {}", response.files.len());
+            for (path, file) in response.files.iter().take(10) {
+                println!(
+                    "  {} — {} bytes, modified: {}",
+                    path,
+                    file.length.unwrap_or(0),
+                    file.last_modified.as_deref().unwrap_or("unknown"),
+                );
+            }
+            if response.files.len() > 10 {
+                println!("  ... and {} more", response.files.len() - 10);
+            }
+
+            if let Some((path, file)) = response.files.iter().next() {
+                println!("\n=== Cloud Save Details (first file) ===\n");
+                println!("  Path:       {}", path);
+                println!("  Filename:   {}", file.file_name.as_deref().unwrap_or("N/A"));
+                println!("  Length:     {} bytes", file.length.unwrap_or(0));
+                println!("  Storage:    {}", file.storage_type.as_deref().unwrap_or("N/A"));
+                println!("  ETag:       {}", file.etag.as_deref().unwrap_or("N/A"));
+                if let Some(link) = &file.read_link {
+                    println!("  Read link:  {}...", &link[..link.len().min(80)]);
+                }
+            }
+        }
+        Err(e) => eprintln!("Failed to list cloud saves: {:?}", e),
+    }
+
+    println!("\n=== Cloud Save List (per game, first asset) ===\n");
+
+    let assets = egs.list_assets(None, None).await;
+    if let Some(asset) = assets.first() {
+        println!("Checking cloud saves for: {}", asset.app_name);
+        match egs.cloud_save_list(Some(&asset.app_name), false).await {
+            Ok(response) => {
+                println!("  Files: {}", response.files.len());
+                for (path, file) in response.files.iter().take(5) {
+                    println!(
+                        "    {} — {} bytes",
+                        path,
+                        file.length.unwrap_or(0),
+                    );
+                }
+            }
+            Err(e) => eprintln!("  No cloud saves or error: {:?}", e),
+        }
+
+        println!("\n=== Cloud Save Manifests ===\n");
+
+        match egs.cloud_save_list(Some(&asset.app_name), true).await {
+            Ok(response) => {
+                println!("  Manifest files: {}", response.files.len());
+                for (path, _) in response.files.iter().take(5) {
+                    println!("    {}", path);
+                }
+            }
+            Err(e) => eprintln!("  No manifests or error: {:?}", e),
+        }
+    } else {
+        println!("No assets found, skipping per-game cloud save demo.");
+    }
+
+    // NOTE: cloud_save_query and cloud_save_delete are available but
+    // require knowing specific filenames and could be destructive.
+    // Uncomment below to try query with known filenames:
+    //
+    // let filenames = vec!["SaveGame1.sav".to_string()];
+    // match egs.cloud_save_query("YourAppName", &filenames).await {
+    //     Ok(response) => println!("Query result: {:#?}", response),
+    //     Err(e) => eprintln!("Query failed: {:?}", e),
+    // }
+}

--- a/examples/uplay.rs
+++ b/examples/uplay.rs
@@ -1,0 +1,55 @@
+#[path = "common.rs"]
+mod common;
+
+use egs_api::EpicGames;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+    let mut egs = EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    println!("=== Uplay Codes ===\n");
+
+    match egs.store_get_uplay_codes().await {
+        Ok(response) => {
+            if let Some(errors) = &response.errors {
+                if !errors.is_empty() {
+                    eprintln!("GraphQL errors: {:?}", errors);
+                }
+            }
+            match response
+                .data
+                .and_then(|d| d.partner_integration)
+                .and_then(|p| p.account_uplay_codes)
+            {
+                Some(codes) => {
+                    println!("Total Uplay codes: {}", codes.len());
+                    for code in &codes {
+                        println!(
+                            "  Game: {} | Uplay Account: {} | Redeemed: {}",
+                            code.game_id.as_deref().unwrap_or("N/A"),
+                            code.uplay_account_id.as_deref().unwrap_or("N/A"),
+                            code.redeemed_on_uplay.unwrap_or(false),
+                        );
+                    }
+                }
+                None => println!("No Uplay codes found (account may not have Ubisoft-linked games)."),
+            }
+        }
+        Err(e) => eprintln!("Failed to fetch Uplay codes: {:?}", e),
+    }
+
+    // Claiming and redeeming require a Uplay account ID and are
+    // irreversible. Uncomment to try with your Uplay account ID:
+    //
+    // let uplay_id = "your-uplay-account-id";
+    // match egs.store_redeem_uplay_codes(uplay_id).await {
+    //     Ok(resp) => println!("Redeem result: {:#?}", resp),
+    //     Err(e) => eprintln!("Redeem failed: {:?}", e),
+    // }
+}

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -49,18 +49,30 @@ impl EpicAPI {
         self.authorized_get_json(&url).await
     }
 
-    /// Fetch all entitlements for the logged-in user.
+    /// Fetch all entitlements for the logged-in user, paginating internally.
     pub async fn user_entitlements(&self) -> Result<Vec<Entitlement>, EpicAPIError> {
-        let url = match &self.user_data.account_id {
-            None => {
-                return Err(EpicAPIError::InvalidCredentials);
+        let id = self
+            .user_data
+            .account_id
+            .as_deref()
+            .ok_or(EpicAPIError::InvalidCredentials)?;
+        let mut all = Vec::new();
+        let mut start: usize = 0;
+        let count: usize = 1000;
+        loop {
+            let url = format!(
+                "https://entitlement-public-service-prod08.ol.epicgames.com/entitlement/api/account/{}/entitlements?start={}&count={}",
+                id, start, count
+            );
+            let batch: Vec<Entitlement> = self.authorized_get_json(&url).await?;
+            let batch_len = batch.len();
+            all.extend(batch);
+            if batch_len < count {
+                break;
             }
-            Some(id) => {
-                format!("https://entitlement-public-service-prod08.ol.epicgames.com/entitlement/api/account/{}/entitlements?start=0&count=5000",
-                        id)
-            }
-        };
-        self.authorized_get_json(&url).await
+            start += count;
+        }
+        Ok(all)
     }
 
     /// Fetch external auth connections for an account.

--- a/src/api/cloud_save.rs
+++ b/src/api/cloud_save.rs
@@ -1,0 +1,64 @@
+use crate::api::error::EpicAPIError;
+use crate::api::types::cloud_save::CloudSaveResponse;
+use crate::api::EpicAPI;
+
+impl EpicAPI {
+    #[allow(dead_code)]
+    /// List cloud save files for a user, optionally filtered by app name.
+    ///
+    /// If `app_name` is provided, lists saves for that specific game.
+    /// If `manifests` is true (only relevant when `app_name` is set), lists manifest files.
+    pub async fn cloud_save_list(
+        &self,
+        app_name: Option<&str>,
+        manifests: bool,
+    ) -> Result<CloudSaveResponse, EpicAPIError> {
+        let user_id = self
+            .user_data
+            .account_id
+            .as_deref()
+            .ok_or(EpicAPIError::InvalidCredentials)?;
+        let app_path = match app_name {
+            Some(name) if manifests => format!("{}/manifests/", name),
+            Some(name) => format!("{}/", name),
+            None => String::new(),
+        };
+        let url = format!(
+            "https://datastorage-public-service-liveegs.live.use1a.on.epicgames.com/api/v1/access/egstore/savesync/{}/{}",
+            user_id, app_path
+        );
+        self.authorized_get_json(&url).await
+    }
+
+    #[allow(dead_code)]
+    /// Query cloud save files by specific filenames (POST with filenames body).
+    ///
+    /// Returns metadata including read/write links for the specified files.
+    pub async fn cloud_save_query(
+        &self,
+        app_name: &str,
+        filenames: &[String],
+    ) -> Result<CloudSaveResponse, EpicAPIError> {
+        let user_id = self
+            .user_data
+            .account_id
+            .as_deref()
+            .ok_or(EpicAPIError::InvalidCredentials)?;
+        let url = format!(
+            "https://datastorage-public-service-liveegs.live.use1a.on.epicgames.com/api/v1/access/egstore/savesync/{}/{}/",
+            user_id, app_name
+        );
+        let body = serde_json::json!({ "files": filenames });
+        self.authorized_post_json(&url, &body).await
+    }
+
+    #[allow(dead_code)]
+    /// Cloud save deletion endpoint.
+    pub async fn cloud_save_delete(&self, path: &str) -> Result<(), EpicAPIError> {
+        let url = format!(
+            "https://datastorage-public-service-liveegs.live.use1a.on.epicgames.com/api/v1/data/egstore/{}",
+            path
+        );
+        self.authorized_delete(&url).await
+    }
+}

--- a/src/api/egs.rs
+++ b/src/api/egs.rs
@@ -155,6 +155,85 @@ impl EpicAPI {
         .await
     }
 
+    /// Fetch an artifact service ticket for EOS Helper manifest retrieval.
+    ///
+    /// The `sandbox_id` is typically the same as the game's namespace,
+    /// and `artifact_id` is the same as the app name.
+    pub async fn artifact_service_ticket(
+        &self,
+        sandbox_id: &str,
+        artifact_id: &str,
+        label: Option<&str>,
+        platform: Option<&str>,
+    ) -> Result<crate::api::types::artifact_service::ArtifactServiceTicket, EpicAPIError> {
+        let url = format!(
+            "https://artifact-public-service-prod.beee.live.use1a.on.epicgames.com/artifact-service/api/public/v1/dependency/sandbox/{}/artifact/{}/ticket",
+            sandbox_id, artifact_id
+        );
+        let body = serde_json::json!({
+            "label": label.unwrap_or("Live"),
+            "expiresInSeconds": 300,
+            "platform": platform.unwrap_or("Windows"),
+        });
+        self.authorized_post_json(&url, &body).await
+    }
+
+    /// Fetch a game manifest using a signed artifact service ticket.
+    ///
+    /// This is an alternative to `asset_manifest` that uses ticket-based auth
+    /// from the EOS Helper service rather than the standard OAuth flow.
+    pub async fn game_manifest_by_ticket(
+        &self,
+        artifact_id: &str,
+        signed_ticket: &str,
+        label: Option<&str>,
+        platform: Option<&str>,
+    ) -> Result<AssetManifest, EpicAPIError> {
+        let url = format!(
+            "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/v2/by-ticket/app/{}",
+            artifact_id
+        );
+        let body = serde_json::json!({
+            "platform": platform.unwrap_or("Windows"),
+            "label": label.unwrap_or("Live"),
+            "signedTicket": signed_ticket,
+        });
+        self.authorized_post_json(&url, &body).await
+    }
+
+    /// Fetch launcher manifests for self-update checks.
+    ///
+    /// Returns the launcher's own asset manifest for a given platform.
+    pub async fn launcher_manifests(
+        &self,
+        platform: Option<&str>,
+        label: Option<&str>,
+    ) -> Result<AssetManifest, EpicAPIError> {
+        let url = format!(
+            "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/v2/platform/{}/launcher?label={}",
+            platform.unwrap_or("Windows"),
+            label.unwrap_or("Live-EternalKnight"),
+        );
+        self.authorized_get_json(&url).await
+    }
+
+    /// Try to fetch a delta manifest for optimized patching between builds.
+    ///
+    /// Delta manifests reduce download size when updating from one version to another.
+    /// Returns `None` if no delta manifest is available (most games don't have them).
+    pub async fn delta_manifest(
+        &self,
+        base_url: &str,
+        old_build_id: &str,
+        new_build_id: &str,
+    ) -> Option<Vec<u8>> {
+        if old_build_id == new_build_id {
+            return None;
+        }
+        let url = format!("{}/Deltas/{}/{}.delta", base_url, new_build_id, old_build_id);
+        self.get_bytes(&url).await.ok()
+    }
+
     /// Fetch all library items, paginating internally.
     pub async fn library_items(&mut self, include_metadata: bool) -> Result<Library, EpicAPIError> {
         let mut library = Library {

--- a/src/api/login.rs
+++ b/src/api/login.rs
@@ -122,6 +122,79 @@ impl EpicAPI {
         }
     }
 
+    /// Authenticate via session ID (SID) from the Epic web login flow.
+    ///
+    /// Performs the web-based exchange: set-sid -> csrf -> exchange/generate,
+    /// then uses the resulting exchange code to start a session.
+    pub async fn auth_sid(&mut self, sid: &str) -> Result<bool, EpicAPIError> {
+        let set_sid_url = format!(
+            "https://www.epicgames.com/id/api/set-sid?sid={}",
+            sid
+        );
+        self.client
+            .get(&set_sid_url)
+            .header(
+                "User-Agent",
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) EpicGamesLauncher/17.0.1 UnrealEngine/4.23.0 Chrome/84.0.4147.38 Safari/537.36",
+            )
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        let csrf_response = self
+            .client
+            .get("https://www.epicgames.com/id/api/csrf")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        let xsrf_token = csrf_response
+            .cookies()
+            .find(|c| c.name() == "XSRF-TOKEN")
+            .map(|c| c.value().to_string())
+            .ok_or_else(|| {
+                error!("XSRF-TOKEN cookie not found");
+                EpicAPIError::InvalidCredentials
+            })?;
+
+        let exchange_response = self
+            .client
+            .post("https://www.epicgames.com/id/api/exchange/generate")
+            .header("X-XSRF-TOKEN", &xsrf_token)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if exchange_response.status() != reqwest::StatusCode::OK {
+            let body = exchange_response.text().await.unwrap_or_default();
+            error!("Exchange code generation failed: {}", body);
+            return Err(EpicAPIError::APIError(
+                "Exchange code generation failed".to_string(),
+            ));
+        }
+
+        let exchange_data: crate::api::types::exchange_code::ExchangeCode =
+            exchange_response.json().await.map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })?;
+
+        let code = exchange_data
+            .code
+            .ok_or(EpicAPIError::InvalidCredentials)?;
+
+        self.start_session(Some(code), None).await
+    }
+
     /// Invalidate the current session (note: method name has a known typo).
     pub async fn invalidate_sesion(&mut self) -> bool {
         if let Some(access_token) = &self.user_data.access_token {

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -28,6 +28,9 @@ pub mod account;
 
 /// EGS Methods
 pub mod egs;
+#[allow(dead_code)]
+/// Cloud Save Methods
+pub mod cloud_save;
 /// Session Handling
 pub mod login;
 
@@ -39,6 +42,9 @@ pub mod status;
 
 /// Presence Methods
 pub mod presence;
+
+/// Uplay/Ubisoft Store Methods
+pub mod store;
 
 #[derive(Debug, Clone)]
 pub(crate) struct EpicAPI {
@@ -203,6 +209,30 @@ impl EpicAPI {
                 error!("{:?}", e);
                 EpicAPIError::DeserializationError(format!("{}", e))
             })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    #[allow(dead_code)]
+    /// Send an authorized DELETE request, returning Ok(()) on success
+    pub(crate) async fn authorized_delete(&self, url: &str) -> Result<(), EpicAPIError> {
+        let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .set_authorization_header(self.client.delete(parsed_url))
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+        if response.status() == reqwest::StatusCode::OK
+            || response.status() == reqwest::StatusCode::NO_CONTENT
+        {
+            Ok(())
         } else {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();

--- a/src/api/store.rs
+++ b/src/api/store.rs
@@ -1,0 +1,159 @@
+use crate::api::error::EpicAPIError;
+use crate::api::types::uplay::{
+    UplayClaimResult, UplayCodesResult, UplayGraphQLResponse, UplayRedeemResult,
+};
+use crate::api::EpicAPI;
+use log::error;
+
+const UPLAY_CODES_QUERY: &str = r#"
+query partnerIntegrationQuery($accountId: String!) {
+  PartnerIntegration {
+    accountUplayCodes(accountId: $accountId) {
+      epicAccountId
+      gameId
+      uplayAccountId
+      regionCode
+      redeemedOnUplay
+      redemptionTimestamp
+    }
+  }
+}
+"#;
+
+const UPLAY_CLAIM_QUERY: &str = r#"
+mutation claimUplayCode($accountId: String!, $uplayAccountId: String!, $gameId: String!) {
+  PartnerIntegration {
+    claimUplayCode(
+      accountId: $accountId
+      uplayAccountId: $uplayAccountId
+      gameId: $gameId
+    ) {
+      data {
+        assignmentTimestam
+        epicAccountId
+        epicEntitlement {
+          entitlementId
+          catalogItemId
+          entitlementName
+          country
+        }
+        gameId
+        redeemedOnUplay
+        redemptionTimestamp
+        regionCode
+        uplayAccountId
+      }
+      success
+    }
+  }
+}
+"#;
+
+const UPLAY_REDEEM_QUERY: &str = r#"
+mutation redeemAllPendingCodes($accountId: String!, $uplayAccountId: String!) {
+  PartnerIntegration {
+    redeemAllPendingCodes(accountId: $accountId, uplayAccountId: $uplayAccountId) {
+      data {
+        epicAccountId
+        uplayAccountId
+        redeemedOnUplay
+        redemptionTimestamp
+      }
+      success
+    }
+  }
+}
+"#;
+
+const STORE_GQL_URL: &str = "https://launcher.store.epicgames.com/graphql";
+const STORE_USER_AGENT: &str = "EpicGamesLauncher/14.0.8-22004686+++Portal+Release-Live";
+
+impl EpicAPI {
+    /// Fetch Uplay codes linked to the user's Epic account via GraphQL.
+    pub async fn store_get_uplay_codes(
+        &self,
+    ) -> Result<UplayGraphQLResponse<UplayCodesResult>, EpicAPIError> {
+        let user_id = self
+            .user_data
+            .account_id
+            .as_deref()
+            .ok_or(EpicAPIError::InvalidCredentials)?;
+        let body = serde_json::json!({
+            "query": UPLAY_CODES_QUERY,
+            "variables": { "accountId": user_id },
+        });
+        self.store_gql_request(&body).await
+    }
+
+    /// Claim a Uplay code for a specific game.
+    pub async fn store_claim_uplay_code(
+        &self,
+        uplay_account_id: &str,
+        game_id: &str,
+    ) -> Result<UplayGraphQLResponse<UplayClaimResult>, EpicAPIError> {
+        let user_id = self
+            .user_data
+            .account_id
+            .as_deref()
+            .ok_or(EpicAPIError::InvalidCredentials)?;
+        let body = serde_json::json!({
+            "query": UPLAY_CLAIM_QUERY,
+            "variables": {
+                "accountId": user_id,
+                "uplayAccountId": uplay_account_id,
+                "gameId": game_id,
+            },
+        });
+        self.store_gql_request(&body).await
+    }
+
+    /// Redeem all pending Uplay codes for the user's account.
+    pub async fn store_redeem_uplay_codes(
+        &self,
+        uplay_account_id: &str,
+    ) -> Result<UplayGraphQLResponse<UplayRedeemResult>, EpicAPIError> {
+        let user_id = self
+            .user_data
+            .account_id
+            .as_deref()
+            .ok_or(EpicAPIError::InvalidCredentials)?;
+        let body = serde_json::json!({
+            "query": UPLAY_REDEEM_QUERY,
+            "variables": {
+                "accountId": user_id,
+                "uplayAccountId": uplay_account_id,
+            },
+        });
+        self.store_gql_request(&body).await
+    }
+
+    /// Internal helper for store GraphQL requests with the required User-Agent.
+    async fn store_gql_request<T: serde::de::DeserializeOwned>(
+        &self,
+        body: &serde_json::Value,
+    ) -> Result<T, EpicAPIError> {
+        let parsed_url =
+            url::Url::parse(STORE_GQL_URL).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .set_authorization_header(self.client.post(parsed_url))
+            .header("User-Agent", STORE_USER_AGENT)
+            .json(body)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+        if response.status() == reqwest::StatusCode::OK {
+            response.json::<T>().await.map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            log::warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+}

--- a/src/api/types/artifact_service.rs
+++ b/src/api/types/artifact_service.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from the artifact service ticket endpoint.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactServiceTicket {
+    pub expires_in_seconds: Option<i64>,
+    pub signed_ticket: Option<String>,
+    pub expiration: Option<String>,
+}

--- a/src/api/types/cloud_save.rs
+++ b/src/api/types/cloud_save.rs
@@ -1,0 +1,26 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Response from cloud save list/query endpoints.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudSaveResponse {
+    pub files: HashMap<String, CloudSaveFile>,
+}
+
+/// Individual cloud save file metadata with read/write links.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudSaveFile {
+    pub file_name: Option<String>,
+    pub read_link: Option<String>,
+    pub write_link: Option<String>,
+    pub last_modified: Option<String>,
+    pub length: Option<i64>,
+    pub storage_type: Option<String>,
+    pub etag: Option<String>,
+    pub unique_filename: Option<String>,
+    pub account_id: Option<String>,
+}

--- a/src/api/types/exchange_code.rs
+++ b/src/api/types/exchange_code.rs
@@ -1,0 +1,8 @@
+use serde::{Deserialize, Serialize};
+
+/// Exchange code response from the web-based SID auth flow.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ExchangeCode {
+    pub code: Option<String>,
+}

--- a/src/api/types/mod.rs
+++ b/src/api/types/mod.rs
@@ -54,3 +54,15 @@ pub mod billing_account;
 
 /// Quick Purchase structures
 pub mod quick_purchase;
+
+/// Cloud Save structures
+pub mod cloud_save;
+
+/// Artifact Service structures
+pub mod artifact_service;
+
+/// Uplay/Ubisoft integration structures
+pub mod uplay;
+
+/// Exchange Code structures
+pub mod exchange_code;

--- a/src/api/types/uplay.rs
+++ b/src/api/types/uplay.rs
@@ -1,0 +1,62 @@
+use serde::{Deserialize, Serialize};
+
+/// GraphQL response wrapper for Uplay partner integration queries.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UplayGraphQLResponse<T> {
+    pub data: Option<UplayPartnerData<T>>,
+    pub errors: Option<Vec<serde_json::Value>>,
+}
+
+/// Partner integration data container.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub struct UplayPartnerData<T> {
+    pub partner_integration: Option<T>,
+}
+
+/// Container for Uplay codes query result.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UplayCodesResult {
+    pub account_uplay_codes: Option<Vec<UplayCode>>,
+}
+
+/// Container for Uplay code claim mutation result.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UplayClaimResult {
+    pub claim_uplay_code: Option<UplayMutationResponse>,
+}
+
+/// Container for Uplay redeem-all mutation result.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UplayRedeemResult {
+    pub redeem_all_pending_codes: Option<UplayMutationResponse>,
+}
+
+/// A Uplay code entry linking an Epic game to a Ubisoft account.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UplayCode {
+    pub epic_account_id: Option<String>,
+    pub game_id: Option<String>,
+    pub uplay_account_id: Option<String>,
+    pub region_code: Option<String>,
+    pub redeemed_on_uplay: Option<bool>,
+    pub redemption_timestamp: Option<String>,
+}
+
+/// Response from a Uplay claim or redeem mutation.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct UplayMutationResponse {
+    pub data: Option<Vec<UplayCode>>,
+    pub success: Option<bool>,
+}

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -53,11 +53,6 @@ pub(crate) fn read_le_64(buffer: &[u8], position: &mut usize) -> u64 {
     u64::from_le_bytes(buffer[*position - 8..*position].try_into().unwrap())
 }
 
-pub(crate) fn read_le_64_signed(buffer: &[u8], position: &mut usize) -> i64 {
-    *position += 8;
-    i64::from_le_bytes(buffer[*position - 8..*position].try_into().unwrap())
-}
-
 pub(crate) fn read_fstring(buffer: &[u8], position: &mut usize) -> Option<String> {
     let mut length = read_le_signed(buffer, position);
     match length.cmp(&0) {
@@ -111,7 +106,7 @@ pub(crate) fn write_fstring(string: &str) -> Vec<u8> {
 mod tests {
     use crate::api::utils::{
         bigblob_to_num, blob_to_num, decode_hex, do_vecs_match, read_fstring, read_le, read_le_64,
-        read_le_64_signed, read_le_signed, write_fstring,
+        read_le_signed, write_fstring,
     };
     use num::bigint::ToBigUint;
 
@@ -163,14 +158,6 @@ mod tests {
         let mut position: usize = 0;
         let buffer = vec![0, 0, 5, 3, 0, 1, 2, 3];
         assert_eq!(read_le_64(&buffer, &mut position), 216736831629492224);
-        assert_eq!(position, 8)
-    }
-
-    #[test]
-    fn read_le_64_signed_test() {
-        let mut position: usize = 0;
-        let buffer = vec![237, 201, 255, 255, 255, 255, 255, 255];
-        assert_eq!(read_le_64_signed(&buffer, &mut position), -13843);
         assert_eq!(position, 8)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,9 +93,11 @@ use crate::api::{EpicAPI};
 
 use api::types::asset_info::{AssetInfo, GameToken};
 use api::types::asset_manifest::AssetManifest;
+use api::types::artifact_service::ArtifactServiceTicket;
 use api::types::billing_account::BillingAccount;
 use api::types::catalog_item::CatalogItemPage;
 use api::types::catalog_offer::CatalogOfferPage;
+use api::types::cloud_save::CloudSaveResponse;
 use api::types::currency::CurrencyPage;
 use api::types::download_manifest::DownloadManifest;
 use api::types::entitlement::Entitlement;
@@ -104,6 +106,9 @@ use api::types::presence::PresenceUpdate;
 use api::types::price::PriceResponse;
 use api::types::quick_purchase::QuickPurchaseResponse;
 use api::types::service_status::ServiceStatus;
+use api::types::uplay::{
+    UplayClaimResult, UplayCodesResult, UplayGraphQLResponse, UplayRedeemResult,
+};
 use log::{error, info, warn};
 use crate::api::error::EpicAPIError;
 
@@ -789,6 +794,132 @@ impl EpicGames {
         self.try_fab_file_download_info(listing_id, format_id, file_id)
             .await
             .ok()
+    }
+
+    // ── Cloud Saves ──
+
+    /// List cloud save files for the logged-in user.
+    ///
+    /// If `app_name` is provided, lists saves for that specific game.
+    /// If `manifests` is true (only relevant when `app_name` is set), lists manifest files.
+    pub async fn cloud_save_list(
+        &self,
+        app_name: Option<&str>,
+        manifests: bool,
+    ) -> Result<CloudSaveResponse, EpicAPIError> {
+        self.egs.cloud_save_list(app_name, manifests).await
+    }
+
+    /// Query cloud save files by specific filenames.
+    ///
+    /// Returns metadata including read/write links for the specified files.
+    pub async fn cloud_save_query(
+        &self,
+        app_name: &str,
+        filenames: &[String],
+    ) -> Result<CloudSaveResponse, EpicAPIError> {
+        self.egs.cloud_save_query(app_name, filenames).await
+    }
+
+    /// Delete a cloud save file by its storage path.
+    pub async fn cloud_save_delete(&self, path: &str) -> Result<(), EpicAPIError> {
+        self.egs.cloud_save_delete(path).await
+    }
+
+    // ── Artifact Service & Manifests ──
+
+    /// Fetch an artifact service ticket for manifest retrieval via EOS Helper.
+    ///
+    /// The `sandbox_id` is typically the game's namespace and `artifact_id`
+    /// is the app name. Returns a signed ticket for use with
+    /// [`game_manifest_by_ticket`](Self::game_manifest_by_ticket).
+    pub async fn artifact_service_ticket(
+        &self,
+        sandbox_id: &str,
+        artifact_id: &str,
+        label: Option<&str>,
+        platform: Option<&str>,
+    ) -> Result<ArtifactServiceTicket, EpicAPIError> {
+        self.egs
+            .artifact_service_ticket(sandbox_id, artifact_id, label, platform)
+            .await
+    }
+
+    /// Fetch a game manifest using a signed artifact service ticket.
+    ///
+    /// Alternative to [`asset_manifest`](Self::asset_manifest) using ticket-based
+    /// auth from the EOS Helper service.
+    pub async fn game_manifest_by_ticket(
+        &self,
+        artifact_id: &str,
+        signed_ticket: &str,
+        label: Option<&str>,
+        platform: Option<&str>,
+    ) -> Result<AssetManifest, EpicAPIError> {
+        self.egs
+            .game_manifest_by_ticket(artifact_id, signed_ticket, label, platform)
+            .await
+    }
+
+    /// Fetch launcher manifests for self-update checks.
+    pub async fn launcher_manifests(
+        &self,
+        platform: Option<&str>,
+        label: Option<&str>,
+    ) -> Result<AssetManifest, EpicAPIError> {
+        self.egs.launcher_manifests(platform, label).await
+    }
+
+    /// Try to fetch a delta manifest for optimized patching between builds.
+    ///
+    /// Returns `None` if no delta is available or the builds are identical.
+    pub async fn delta_manifest(
+        &self,
+        base_url: &str,
+        old_build_id: &str,
+        new_build_id: &str,
+    ) -> Option<Vec<u8>> {
+        self.egs
+            .delta_manifest(base_url, old_build_id, new_build_id)
+            .await
+    }
+
+    // ── SID Auth ──
+
+    /// Authenticate via session ID (SID) from the Epic web login flow.
+    ///
+    /// Performs the multi-step web exchange: set-sid → CSRF → exchange code,
+    /// then starts a session with the resulting code. Returns `true` on success.
+    pub async fn auth_sid(&mut self, sid: &str) -> Result<bool, EpicAPIError> {
+        self.egs.auth_sid(sid).await
+    }
+
+    // ── Uplay / Ubisoft Store ──
+
+    /// Fetch Uplay codes linked to the user's Epic account.
+    pub async fn store_get_uplay_codes(
+        &self,
+    ) -> Result<UplayGraphQLResponse<UplayCodesResult>, EpicAPIError> {
+        self.egs.store_get_uplay_codes().await
+    }
+
+    /// Claim a Uplay code for a specific game.
+    pub async fn store_claim_uplay_code(
+        &self,
+        uplay_account_id: &str,
+        game_id: &str,
+    ) -> Result<UplayGraphQLResponse<UplayClaimResult>, EpicAPIError> {
+        self.egs
+            .store_claim_uplay_code(uplay_account_id, game_id)
+            .await
+    }
+
+    /// Redeem all pending Uplay codes for the user's account.
+    pub async fn store_redeem_uplay_codes(
+        &self,
+        uplay_account_id: &str,
+    ) -> Result<UplayGraphQLResponse<UplayRedeemResult>, EpicAPIError> {
+        self.egs.store_redeem_uplay_codes(uplay_account_id).await
     }
 }
 


### PR DESCRIPTION
… auth

Add cloud save API (list, query, delete), Uplay/store GraphQL integration (get/claim/redeem activation codes), artifact service ticket flow, launcher manifests, delta manifests, and SID-based authentication.

Fix entitlement pagination (now loops with count=1000 instead of single count=5000 request). Remove dead read_le_64_signed (superseded by BinaryReader::read_i64).

New examples: cloud_saves, uplay. Updated: assets, auth. Updated README and CHANGELOG.