### PR TITLE
Upgrade reqwest 0.12 → 0.13, bump to 0.10.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = "1.82"
 autoexamples = false
 
 [dependencies]
-reqwest = { version = "0.12", features = ["json", "cookies"] }
+reqwest = { version = "0.13", features = ["json", "cookies", "form"] }
 serde_json = "1.0"
 serde_with = "3"
 url = { version = "2.5", features = ["serde"] }
@@ -23,8 +23,6 @@ log = "0.4"
 sha-1 = "0.10"
 flate2 = "1"
 num = "0.4"
-reqwest_cookie_store = "0.8.0"
-cookie_store = "0.21.0"
 uuid = { version = "1", features = ["v4", "serde"] }
 time = { version = "^0.3", features = ["serde", "parsing", "serde-well-known"] }
 
@@ -39,7 +37,7 @@ features = ["derive"]
 [dev-dependencies]
 webbrowser = "1"
 env_logger = "0.11"
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest = { version = "0.13", features = ["blocking"] }
 
 [[example]]
 name = "workflow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egs-api"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Milan Šťastný <milan@acheta.games>"]
 description = "Interface to the Epic Games API"
 categories = ["api-bindings", "asynchronous", "games"]


### PR DESCRIPTION
## Summary

- Upgrade reqwest from 0.12 to 0.13, adding the `form` feature flag (now required for `.form()` in 0.13)
- Remove unused `reqwest_cookie_store` and `cookie_store` dependencies
- Bump version to 0.10.1

## Verification

- 86 tests pass
- All 15 examples compile clean
- No public API changes (reqwest types are not exposed)