### PR TITLE
Add Cosmos session, Fab search/browse, and engine blob APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egs-api"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["Milan Šťastný <milan@acheta.games>"]
 description = "Interface to the Epic Games API"
 categories = ["api-bindings", "asynchronous", "games"]
@@ -98,6 +98,10 @@ path = "examples/cloud_saves.rs"
 [[example]]
 name = "uplay"
 path = "examples/uplay.rs"
+
+[[example]]
+name = "cosmos"
+path = "examples/cosmos.rs"
 
 [[example]]
 name = "compare_manifests"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ Built on `reqwest` / `tokio`.
   Exposes file lists, chunk hashes, and custom fields needed to reconstruct
   downloads.
 - **Fab Marketplace** — List Fab library items, fetch Fab asset manifests with
-  signed distribution points, and download Fab manifests.
+  signed distribution points, and download Fab manifests. Search and browse
+  listings with filtering, view listing details, UE format specs, ownership,
+  and pricing.
+- **Cosmos / Unreal Engine** — Cookie-based session for unrealengine.com.
+  EULA management, account details, and engine version blob listing.
 - **Account** — Account details, bulk account ID lookup, friends list
   (including pending requests).
 - **Entitlements** — Query all user entitlements (games, DLC, subscriptions).
@@ -110,7 +114,8 @@ cargo run --example entitlements         # List all entitlements
 cargo run --example library              # Paginated library listing
 cargo run --example assets               # Full pipeline: list → info → manifest → download manifest
 cargo run --example game_token           # Exchange code + ownership token
-cargo run --example fab                  # Fab library → asset manifest → download manifest
+cargo run --example fab                  # Fab search, browse, listing detail, library, downloads
+cargo run --example cosmos               # Cosmos session, EULA, account, engine versions
 cargo run --example catalog              # Catalog items, offers, bulk lookup
 cargo run --example commerce             # Currencies, prices, billing, quick purchase
 cargo run --example status               # Service status (lightswitch API)
@@ -184,6 +189,26 @@ distinctions.
 | `fab_asset_manifest(artifact_id, namespace, asset_id, platform)` | Signed download info with distribution points |
 | `fab_download_manifest(download_info, distribution_point_url)` | Parse download manifest from a specific CDN |
 | `fab_file_download_info(listing_id, format_id, file_id)` | Download info for a specific Fab file |
+| `fab_search(params)` | Search/browse listings with filters, sorting, pagination |
+| `fab_listing(uid)` | Full listing detail (title, seller, category, ratings) |
+| `fab_listing_ue_formats(uid)` | UE-specific format specs (engine versions, platforms) |
+| `fab_listing_state(uid)` | Ownership, wishlist, and review state for a listing |
+| `fab_listing_states_bulk(listing_ids)` | Bulk check listing states |
+| `fab_bulk_prices(offer_ids)` | Bulk fetch pricing for multiple offers |
+| `fab_listing_ownership(uid)` | Detailed ownership/license info for a listing |
+
+### Cosmos / Unreal Engine
+
+| Method | Description |
+|--------|-------------|
+| `cosmos_session_setup(exchange_code)` | Set up a Cosmos cookie session from an exchange code |
+| `cosmos_auth_upgrade()` | Upgrade bearer token to Cosmos session |
+| `cosmos_eula_check(eula_id, locale)` | Check if a EULA has been accepted |
+| `cosmos_eula_accept(eula_id, locale, version)` | Accept a EULA |
+| `cosmos_account()` | Cosmos account details |
+| `cosmos_policy_aodc()` | Age of Digital Consent policy status |
+| `cosmos_comm_opt_in(setting)` | Communication opt-in status |
+| `engine_versions(platform)` | Engine version download blobs for a platform |
 
 ### Account & Social
 
@@ -242,7 +267,8 @@ EpicGames (public facade, src/lib.rs)
         ├── login.rs    — OAuth: start, resume, invalidate
         ├── egs.rs      — Assets, manifests, library, cloud saves, tokens
         ├── account.rs  — Account details, friends, entitlements
-        ├── fab.rs      — Fab marketplace integration
+        ├── fab.rs      — Fab marketplace: library, downloads, search, browse
+        ├── cosmos.rs   — Cosmos session, EULA, account, engine versions
         └── store.rs    — Uplay/Ubisoft code redemption (GraphQL)
 ```
 

--- a/examples/cosmos.rs
+++ b/examples/cosmos.rs
@@ -1,0 +1,62 @@
+//! Cosmos session setup, EULA check, and engine version listing.
+//!
+//! Run: `cargo run --example cosmos`
+
+#[path = "common.rs"]
+mod common;
+
+use egs_api::api::types::cosmos::CosmosEulaResponse;
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    let mut egs = egs_api::EpicGames::new();
+
+    if !common::login_or_restore(&mut egs).await {
+        eprintln!("Authentication failed. Run the 'auth' example first.");
+        std::process::exit(1);
+    }
+
+    // Get a game token (exchange code) to bootstrap the Cosmos session
+    let token = egs
+        .try_game_token()
+        .await
+        .expect("Failed to get game token");
+
+    println!("Exchange code obtained, setting up Cosmos session...");
+
+    // Set up cookie-based Cosmos session
+    let auth = egs
+        .cosmos_session_setup(&token.code)
+        .await
+        .expect("Cosmos session setup failed");
+
+    println!(
+        "Cosmos auth: bearerTokenValid={}, upgradedBearerToken={}",
+        auth.bearer_token_valid, auth.upgraded_bearer_token
+    );
+
+    // Check EULA acceptance
+    let eula: CosmosEulaResponse = egs
+        .try_cosmos_eula_check("unreal_engine2", "en")
+        .await
+        .expect("EULA check failed");
+    println!("UE EULA accepted: {}", eula.accepted);
+
+    // Get Cosmos account info
+    if let Some(account) = egs.cosmos_account().await {
+        println!("Account: {} ({})", account.display_name, account.country);
+    }
+
+    // Fetch engine versions for Linux
+    if let Some(versions) = egs.engine_versions("linux").await {
+        println!("\nLinux engine builds ({} blobs):", versions.blobs.len());
+        for blob in versions.blobs.iter().take(5) {
+            println!("  {} ({} bytes)", blob.name, blob.size);
+        }
+        if versions.blobs.len() > 5 {
+            println!("  ... and {} more", versions.blobs.len() - 5);
+        }
+    }
+}

--- a/examples/fab.rs
+++ b/examples/fab.rs
@@ -1,6 +1,7 @@
 #[path = "common.rs"]
 mod common;
 
+use egs_api::api::types::fab_search::FabSearchParams;
 use egs_api::EpicGames;
 
 #[tokio::main]
@@ -19,7 +20,191 @@ async fn main() {
         std::process::exit(1);
     }
 
-    println!("=== Fab Library ===\n");
+    // --- Search (public, no auth required) ---
+
+    println!("=== Fab Search (UE plugins, newest first) ===\n");
+
+    let params = FabSearchParams {
+        channels: Some("unreal-engine".to_string()),
+        listing_types: Some("tool-and-plugin".to_string()),
+        sort_by: Some("-createdAt".to_string()),
+        count: Some(5),
+        ..Default::default()
+    };
+
+    match egs.fab_search(&params).await {
+        Some(results) => {
+            println!(
+                "Found {} results (showing first {})",
+                results.count.unwrap_or(0),
+                results.results.len()
+            );
+            for listing in &results.results {
+                let title = listing.title.as_deref().unwrap_or("(untitled)");
+                let seller = listing
+                    .user
+                    .as_ref()
+                    .and_then(|u| u.seller_name.as_deref())
+                    .unwrap_or("unknown");
+                let listing_type = listing.listing_type.as_deref().unwrap_or("?");
+                println!("  [{}] {} — by {}", listing_type, title, seller);
+
+                if let Some(cat) = &listing.category {
+                    if let Some(name) = &cat.name {
+                        println!("    Category: {}", name);
+                    }
+                }
+            }
+            if let Some(ref cursors) = results.cursors {
+                if cursors.next.is_some() {
+                    println!("  (more results available via cursor pagination)");
+                }
+            }
+
+            // --- Listing Detail for the first result ---
+
+            if let Some(first) = results.results.first() {
+                println!(
+                    "\n=== Listing Detail: {} ===\n",
+                    first.title.as_deref().unwrap_or(&first.uid)
+                );
+
+                if let Some(detail) = egs.fab_listing(&first.uid).await {
+                    println!("  UID:         {}", detail.uid);
+                    println!(
+                        "  Title:       {}",
+                        detail.title.as_deref().unwrap_or("(none)")
+                    );
+                    println!(
+                        "  Type:        {}",
+                        detail.listing_type.as_deref().unwrap_or("(none)")
+                    );
+                    println!(
+                        "  Seller:      {}",
+                        detail
+                            .user
+                            .as_ref()
+                            .and_then(|u| u.seller_name.as_deref())
+                            .unwrap_or("unknown")
+                    );
+                    println!("  Mature:      {}", detail.is_mature.unwrap_or(false));
+                    println!(
+                        "  Created:     {}",
+                        detail.created_at.as_deref().unwrap_or("?")
+                    );
+                    println!(
+                        "  Published:   {}",
+                        detail.published_at.as_deref().unwrap_or("?")
+                    );
+                    if let Some(ratings) = &detail.ratings {
+                        println!("  Ratings:     {}", ratings);
+                    }
+                } else {
+                    eprintln!("  Failed to fetch listing detail");
+                }
+
+                // --- UE Format Details ---
+
+                println!("\n=== UE Format Details ===\n");
+
+                match egs.fab_listing_ue_formats(&first.uid).await {
+                    Some(formats) => {
+                        println!("  {} format(s):", formats.len());
+                        for fmt in &formats {
+                            if let Some(ref ft) = fmt.asset_format_type {
+                                println!(
+                                    "    Format: {} ({})",
+                                    ft.name.as_deref().unwrap_or("?"),
+                                    ft.code.as_deref().unwrap_or("?")
+                                );
+                            }
+                            if let Some(ref specs) = fmt.technical_specs {
+                                if let Some(ref versions) =
+                                    specs.unreal_engine_engine_versions
+                                {
+                                    println!(
+                                        "    Engine versions: {}",
+                                        versions.join(", ")
+                                    );
+                                }
+                                if let Some(ref platforms) =
+                                    specs.unreal_engine_target_platforms
+                                {
+                                    println!(
+                                        "    Platforms: {}",
+                                        platforms.join(", ")
+                                    );
+                                }
+                                if let Some(ref method) =
+                                    specs.unreal_engine_distribution_method
+                                {
+                                    println!("    Distribution: {}", method);
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        println!("  No UE format info available for this listing");
+                    }
+                }
+
+                // --- Listing State (requires auth) ---
+
+                println!("\n=== Listing State ===\n");
+
+                match egs.fab_listing_state(&first.uid).await {
+                    Some(state) => {
+                        println!(
+                            "  Acquired:    {}",
+                            state.acquired.unwrap_or(false)
+                        );
+                        println!(
+                            "  Wishlisted:  {}",
+                            state.wishlisted.unwrap_or(false)
+                        );
+                        if let Some(ref eid) = state.entitlement_id {
+                            println!("  Entitlement: {}", eid);
+                        }
+                    }
+                    None => {
+                        println!("  Could not fetch listing state (may require Fab session)");
+                    }
+                }
+
+                // --- Ownership ---
+
+                println!("\n=== Listing Ownership ===\n");
+
+                match egs.fab_listing_ownership(&first.uid).await {
+                    Some(ownership) => {
+                        if let Some(ref licenses) = ownership.licenses {
+                            if licenses.is_empty() {
+                                println!("  Not owned");
+                            } else {
+                                for lic in licenses {
+                                    println!(
+                                        "  License: {} ({})",
+                                        lic.name.as_deref().unwrap_or("?"),
+                                        lic.slug.as_deref().unwrap_or("?")
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    None => {
+                        println!("  Could not fetch ownership info");
+                    }
+                }
+            }
+        }
+        None => {
+            eprintln!("Fab search failed");
+        }
+    }
+
+    // --- Library (requires auth) ---
+
+    println!("\n=== Fab Library ===\n");
 
     match egs.fab_library_items(account_id).await {
         Some(library) => {
@@ -36,6 +221,8 @@ async fn main() {
             return;
         }
     }
+
+    // --- Asset Manifest ---
 
     println!("\n=== Fab Asset Manifest (Kite Demo) ===\n");
 
@@ -89,6 +276,8 @@ async fn main() {
         }
         Err(e) => eprintln!("Failed to fetch Fab asset manifest: {:?}", e),
     }
+
+    // --- File Download Info ---
 
     println!("\n=== Fab File Download Info ===\n");
 

--- a/src/api/cosmos.rs
+++ b/src/api/cosmos.rs
@@ -1,0 +1,335 @@
+use crate::api::error::EpicAPIError;
+use crate::api::types::cosmos::{
+    CosmosAccount, CosmosAuthResponse, CosmosCommOptIn, CosmosEulaResponse, CosmosPolicyAodc,
+};
+use crate::api::types::engine_blob::EngineBlobsResponse;
+use crate::api::EpicAPI;
+use log::{debug, error, warn};
+use serde::Deserialize;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RedirectResponse {
+    #[allow(dead_code)]
+    redirect_url: Option<String>,
+    #[allow(dead_code)]
+    authorization_code: Option<serde_json::Value>,
+    sid: Option<String>,
+}
+
+impl EpicAPI {
+    /// Set up a Cosmos cookie session from an exchange code.
+    ///
+    /// Performs the full web-based flow:
+    /// 1. `GET /id/api/reputation` — sets XSRF-TOKEN cookie
+    /// 2. `POST /id/api/exchange` — sends exchange code with XSRF
+    /// 3. `GET /id/api/redirect` — gets SID
+    /// 4. `GET /id/api/set-sid?sid=X` — sets session cookies on unrealengine.com
+    /// 5. `GET /api/cosmos/auth` — upgrades bearer token, sets EPIC_EG1 JWTs
+    ///
+    /// After success, all Cosmos endpoints (`cosmos_*` methods)
+    /// work automatically via cookies in the client's cookie jar.
+    pub async fn cosmos_session_setup(
+        &self,
+        exchange_code: &str,
+    ) -> Result<CosmosAuthResponse, EpicAPIError> {
+        let rep_response = self
+            .client
+            .get("https://www.epicgames.com/id/api/reputation")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed to get XSRF token: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        let xsrf = rep_response
+            .cookies()
+            .find(|c| c.name() == "XSRF-TOKEN")
+            .map(|c| c.value().to_string())
+            .ok_or_else(|| {
+                error!("XSRF-TOKEN cookie not found in reputation response");
+                EpicAPIError::InvalidCredentials
+            })?;
+
+        let exchange_body = serde_json::json!({"exchangeCode": exchange_code});
+        let exchange_resp = self
+            .client
+            .post("https://www.epicgames.com/id/api/exchange")
+            .json(&exchange_body)
+            .header("x-xsrf-token", &xsrf)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed exchange code: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if !exchange_resp.status().is_success() {
+            let status = exchange_resp.status();
+            let body = exchange_resp.text().await.unwrap_or_default();
+            warn!("Exchange failed: {} {}", status, body);
+            return Err(EpicAPIError::HttpError { status, body });
+        }
+
+        let redirect_resp = self
+            .client
+            .get("https://www.epicgames.com/id/api/redirect?")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed redirect: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        let redirect: RedirectResponse = redirect_resp.json().await.map_err(|e| {
+            error!("Failed to parse redirect response: {:?}", e);
+            EpicAPIError::DeserializationError(format!("{}", e))
+        })?;
+
+        let sid = redirect.sid.ok_or_else(|| {
+            error!("No SID in redirect response");
+            EpicAPIError::InvalidCredentials
+        })?;
+
+        let set_sid_resp = self
+            .client
+            .get(format!(
+                "https://www.unrealengine.com/id/api/set-sid?sid={}",
+                sid
+            ))
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed set-sid: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+        debug!("set-sid status={}", set_sid_resp.status());
+
+        self.cosmos_auth_upgrade().await
+    }
+
+    /// Upgrade the session by calling `GET /api/cosmos/auth`.
+    ///
+    /// Converts base session cookies (from `set-sid`) into upgraded EPIC_EG1 JWTs.
+    pub async fn cosmos_auth_upgrade(&self) -> Result<CosmosAuthResponse, EpicAPIError> {
+        let response = self
+            .client
+            .get("https://www.unrealengine.com/api/cosmos/auth")
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed cosmos auth: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if response.status().is_success() {
+            response.json::<CosmosAuthResponse>().await.map_err(|e| {
+                error!("Failed to parse cosmos auth response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("cosmos/auth failed: {} {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Check if a EULA has been accepted.
+    ///
+    /// Requires an active Cosmos session (call `cosmos_session_setup` first).
+    /// Known EULA IDs: `unreal_engine`, `unreal_engine2`, `realityscan`, `mhc`, `content`.
+    pub async fn cosmos_eula_check(
+        &self,
+        eula_id: &str,
+        locale: &str,
+    ) -> Result<CosmosEulaResponse, EpicAPIError> {
+        let url = format!(
+            "https://www.unrealengine.com/api/cosmos/eula/accept?eulaId={}&locale={}",
+            eula_id, locale
+        );
+        let response = self
+            .client
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed EULA check: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if response.status().is_success() {
+            response.json::<CosmosEulaResponse>().await.map_err(|e| {
+                error!("Failed to parse EULA response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("EULA check failed: {} {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Accept a EULA.
+    ///
+    /// Requires an active Cosmos session. The web UI sends
+    /// `eulaId=unreal_engine2&locale=en&version=3`.
+    pub async fn cosmos_eula_accept(
+        &self,
+        eula_id: &str,
+        locale: &str,
+        version: u32,
+    ) -> Result<CosmosEulaResponse, EpicAPIError> {
+        let url = format!(
+            "https://www.unrealengine.com/api/cosmos/eula/accept?eulaId={}&locale={}&version={}",
+            eula_id, locale, version
+        );
+        let response = self
+            .client
+            .post(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed EULA accept: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if response.status().is_success() {
+            response.json::<CosmosEulaResponse>().await.map_err(|e| {
+                error!("Failed to parse EULA accept response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("EULA accept failed: {} {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Get Cosmos account details. Requires an active Cosmos session.
+    pub async fn cosmos_account(&self) -> Result<CosmosAccount, EpicAPIError> {
+        let response = self
+            .client
+            .get("https://www.unrealengine.com/api/cosmos/account")
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed cosmos account: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if response.status().is_success() {
+            response.json::<CosmosAccount>().await.map_err(|e| {
+                error!("Failed to parse cosmos account response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("cosmos/account failed: {} {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Check Age of Digital Consent policy. Requires an active Cosmos session.
+    pub async fn cosmos_policy_aodc(&self) -> Result<CosmosPolicyAodc, EpicAPIError> {
+        let response = self
+            .client
+            .get("https://www.unrealengine.com/api/cosmos/policy/aodc")
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed cosmos policy check: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if response.status().is_success() {
+            response.json::<CosmosPolicyAodc>().await.map_err(|e| {
+                error!("Failed to parse policy response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("cosmos/policy/aodc failed: {} {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Check communication opt-in status.
+    ///
+    /// Known settings: `email:ue` (Unreal Engine), likely also `email:fn` (Fortnite).
+    /// Requires an active Cosmos session.
+    pub async fn cosmos_comm_opt_in(
+        &self,
+        setting: &str,
+    ) -> Result<CosmosCommOptIn, EpicAPIError> {
+        let url = format!(
+            "https://www.unrealengine.com/api/cosmos/communication/opt-in?setting={}",
+            setting
+        );
+        let response = self
+            .client
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed cosmos comm opt-in: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if response.status().is_success() {
+            response.json::<CosmosCommOptIn>().await.map_err(|e| {
+                error!("Failed to parse comm opt-in response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("cosmos/communication/opt-in failed: {} {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Fetch engine version blobs (download URLs) for a platform.
+    ///
+    /// Requires an active Cosmos session (cookies from set-sid + cosmos/auth).
+    /// Platform values: `linux`, `windows`, `mac`
+    pub async fn engine_versions(
+        &self,
+        platform: &str,
+    ) -> Result<EngineBlobsResponse, EpicAPIError> {
+        let url = format!("https://www.unrealengine.com/api/blobs/{}", platform);
+        let response = self
+            .client
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await
+            .map_err(|e| {
+                error!("Failed engine versions: {:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+
+        if response.status().is_success() {
+            response.json::<EngineBlobsResponse>().await.map_err(|e| {
+                error!("Failed to parse engine versions response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("blobs/{} failed: {} {}", platform, status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+}

--- a/src/api/fab.rs
+++ b/src/api/fab.rs
@@ -147,4 +147,114 @@ impl EpicAPI {
         );
         self.authorized_get_json(&url).await
     }
+
+    /// Search Fab listings. Public endpoint — no auth required.
+    ///
+    /// Use `FabSearchParams` to specify filters, sorting, and pagination.
+    pub async fn fab_search(
+        &self,
+        params: &crate::api::types::fab_search::FabSearchParams,
+    ) -> Result<crate::api::types::fab_search::FabSearchResults, EpicAPIError> {
+        let mut url = "https://www.fab.com/i/listings/search?".to_string();
+        let mut query_parts = Vec::new();
+
+        if let Some(ref channels) = params.channels {
+            query_parts.push(format!("channels={}", channels));
+        }
+        if let Some(ref listing_types) = params.listing_types {
+            query_parts.push(format!("listing_types={}", listing_types));
+        }
+        if let Some(ref categories) = params.categories {
+            query_parts.push(format!("categories={}", categories));
+        }
+        if let Some(ref sort_by) = params.sort_by {
+            query_parts.push(format!("sort_by={}", sort_by));
+        }
+        if let Some(count) = params.count {
+            query_parts.push(format!("count={}", count));
+        }
+        if let Some(ref cursor) = params.cursor {
+            query_parts.push(format!("cursor={}", cursor));
+        }
+        if let Some(ref aggregate_on) = params.aggregate_on {
+            query_parts.push(format!("aggregate_on={}", aggregate_on));
+        }
+        if let Some(ref in_filter) = params.in_filter {
+            query_parts.push(format!("in={}", in_filter));
+        }
+        if let Some(is_discounted) = params.is_discounted {
+            if is_discounted {
+                query_parts.push("is_discounted=true".to_string());
+            }
+        }
+
+        url.push_str(&query_parts.join("&"));
+        self.get_json(&url).await
+    }
+
+    /// Get full listing detail. Public endpoint — no auth required.
+    pub async fn fab_listing(
+        &self,
+        uid: &str,
+    ) -> Result<crate::api::types::fab_search::FabListingDetail, EpicAPIError> {
+        let url = format!("https://www.fab.com/i/listings/{}", uid);
+        self.get_json(&url).await
+    }
+
+    /// Get UE-specific format details for a listing. Public endpoint.
+    pub async fn fab_listing_ue_formats(
+        &self,
+        uid: &str,
+    ) -> Result<Vec<crate::api::types::fab_search::FabListingUeFormat>, EpicAPIError> {
+        let url = format!(
+            "https://www.fab.com/i/listings/{}/asset-formats/unreal-engine",
+            uid
+        );
+        self.get_json(&url).await
+    }
+
+    /// Get user's listing state (ownership, wishlist, review). Requires Fab session.
+    pub async fn fab_listing_state(
+        &self,
+        uid: &str,
+    ) -> Result<crate::api::types::fab_search::FabListingState, EpicAPIError> {
+        let url = format!("https://www.fab.com/i/users/me/listings-states/{}", uid);
+        self.authorized_get_json(&url).await
+    }
+
+    /// Bulk check listing states for multiple IDs. Requires Fab session.
+    pub async fn fab_listing_states_bulk(
+        &self,
+        listing_ids: &[&str],
+    ) -> Result<Vec<crate::api::types::fab_search::FabListingState>, EpicAPIError> {
+        let ids = listing_ids.join(",");
+        let url = format!(
+            "https://www.fab.com/i/users/me/listings-states?listing_ids={}",
+            ids
+        );
+        self.authorized_get_json(&url).await
+    }
+
+    /// Bulk fetch pricing for multiple offer IDs. Public endpoint.
+    pub async fn fab_bulk_prices(
+        &self,
+        offer_ids: &[&str],
+    ) -> Result<Vec<crate::api::types::fab_search::FabPriceInfo>, EpicAPIError> {
+        let ids = offer_ids
+            .iter()
+            .map(|id| format!("offer_ids={}", id))
+            .collect::<Vec<_>>()
+            .join("&");
+        let url = format!("https://www.fab.com/i/listings/prices-infos?{}", ids);
+        self.get_json(&url).await
+    }
+
+    /// Get listing ownership info. Requires Fab session.
+    pub async fn fab_listing_ownership(
+        &self,
+        uid: &str,
+    ) -> Result<crate::api::types::fab_search::FabOwnership, EpicAPIError> {
+        let url = format!("https://www.fab.com/i/listings/{}/ownership", uid);
+        self.authorized_get_json(&url).await
+    }
 }

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -46,6 +46,9 @@ pub mod presence;
 /// Uplay/Ubisoft Store Methods
 pub mod store;
 
+/// Cosmos session and API methods (unrealengine.com cookie-based)
+pub mod cosmos;
+
 #[derive(Debug, Clone)]
 pub(crate) struct EpicAPI {
     client: Client,
@@ -206,6 +209,29 @@ impl EpicAPI {
             })?;
         if response.status() == reqwest::StatusCode::OK {
             response.bytes().await.map(|b| b.to_vec()).map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Send an unauthenticated GET request and deserialize the JSON response
+    pub(crate) async fn get_json<T: DeserializeOwned>(
+        &self,
+        url: &str,
+    ) -> Result<T, EpicAPIError> {
+        let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self.client.get(parsed_url).send().await.map_err(|e| {
+            error!("{:?}", e);
+            EpicAPIError::NetworkError(e)
+        })?;
+        if response.status() == reqwest::StatusCode::OK {
+            response.json::<T>().await.map_err(|e| {
                 error!("{:?}", e);
                 EpicAPIError::DeserializationError(format!("{}", e))
             })

--- a/src/api/types/cosmos.rs
+++ b/src/api/types/cosmos.rs
@@ -1,0 +1,121 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from `GET /api/cosmos/auth` — session upgrade result.
+///
+/// After calling `set-sid`, this endpoint upgrades the bearer token and
+/// issues EPIC_EG1 / EPIC_EG1_REFRESH JWTs (set as cookies) required
+/// by all other `/api/cosmos/*` endpoints.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CosmosAuthResponse {
+    pub bearer_token_valid: bool,
+    pub cleared_offline: bool,
+    pub upgraded_bearer_token: bool,
+    pub account_id: String,
+}
+
+/// Error response from Cosmos when not authenticated.
+///
+/// Returned as `{"error": "Not logged in", "isLoggedIn": false}`
+/// when EPIC_EG1 cookie is missing or expired.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CosmosAuthError {
+    pub error: String,
+    pub is_logged_in: bool,
+}
+
+/// Response from `GET /api/cosmos/account` — account info.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CosmosAccount {
+    pub country: String,
+    pub display_name: String,
+    pub email: String,
+    pub id: String,
+    pub preferred_language: String,
+    pub cabined_mode: bool,
+    pub is_logged_in: bool,
+}
+
+/// Response from `GET/POST /api/cosmos/eula/accept`.
+///
+/// GET checks if a EULA is accepted; POST accepts it.
+/// Known EULA IDs: `unreal_engine`, `unreal_engine2`, `realityscan`, `mhc`, `content`
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CosmosEulaResponse {
+    pub accepted: bool,
+}
+
+/// Response from `GET /api/cosmos/policy/aodc` — Age of Digital Consent.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CosmosPolicyAodc {
+    pub failed: bool,
+}
+
+/// Response from `GET /api/cosmos/communication/opt-in`.
+#[allow(missing_docs)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CosmosCommOptIn {
+    pub setting_value: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_cosmos_auth() {
+        let json = r#"{"bearerTokenValid":true,"clearedOffline":false,"upgradedBearerToken":true,"accountId":"8645b4947bbc4c0092a8b7236df169d1"}"#;
+        let auth: CosmosAuthResponse = serde_json::from_str(json).unwrap();
+        assert!(auth.bearer_token_valid);
+        assert!(auth.upgraded_bearer_token);
+        assert_eq!(auth.account_id, "8645b4947bbc4c0092a8b7236df169d1");
+    }
+
+    #[test]
+    fn deserialize_cosmos_auth_error() {
+        let json = r#"{"error":"Not logged in","isLoggedIn":false}"#;
+        let err: CosmosAuthError = serde_json::from_str(json).unwrap();
+        assert_eq!(err.error, "Not logged in");
+        assert!(!err.is_logged_in);
+    }
+
+    #[test]
+    fn deserialize_cosmos_eula() {
+        let json = r#"{"accepted":true}"#;
+        let eula: CosmosEulaResponse = serde_json::from_str(json).unwrap();
+        assert!(eula.accepted);
+    }
+
+    #[test]
+    fn deserialize_cosmos_account() {
+        let json = r#"{"country":"CZ","displayName":"Acheta Games","email":"m***n@stastnej.ch","id":"8645b4947bbc4c0092a8b7236df169d1","preferredLanguage":"en","cabinedMode":false,"isLoggedIn":true}"#;
+        let account: CosmosAccount = serde_json::from_str(json).unwrap();
+        assert_eq!(account.country, "CZ");
+        assert_eq!(account.display_name, "Acheta Games");
+        assert!(account.is_logged_in);
+    }
+
+    #[test]
+    fn deserialize_policy_aodc() {
+        let json = r#"{"failed":false}"#;
+        let policy: CosmosPolicyAodc = serde_json::from_str(json).unwrap();
+        assert!(!policy.failed);
+    }
+
+    #[test]
+    fn deserialize_comm_opt_in() {
+        let json = r#"{"settingValue":false}"#;
+        let opt: CosmosCommOptIn = serde_json::from_str(json).unwrap();
+        assert!(!opt.setting_value);
+    }
+}

--- a/src/api/types/engine_blob.rs
+++ b/src/api/types/engine_blob.rs
@@ -1,0 +1,47 @@
+use serde::{Deserialize, Serialize};
+
+/// Response from `GET /api/blobs/{platform}` — engine version downloads.
+///
+/// Contains presigned download URLs for Unreal Engine builds,
+/// Fab plugins, and Bridge plugins for the specified platform.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineBlobsResponse {
+    pub blobs: Vec<EngineBlob>,
+}
+
+/// A single engine download blob.
+///
+/// The `url` field contains a presigned S3 URL with limited expiry.
+/// The `name` field contains the filename, e.g. `Linux_Unreal_Engine_5.7.3.zip`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EngineBlob {
+    pub name: String,
+    pub created_at: String,
+    pub size: u64,
+    pub url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_engine_blobs() {
+        let json = r#"{"blobs":[{"name":"Linux_Unreal_Engine_5.7.3.zip","createdAt":"2026-01-15T10:00:00Z","size":12345678,"url":"https://example.com/blob"}]}"#;
+        let resp: EngineBlobsResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(resp.blobs.len(), 1);
+        assert_eq!(resp.blobs[0].name, "Linux_Unreal_Engine_5.7.3.zip");
+        assert_eq!(resp.blobs[0].size, 12345678);
+    }
+
+    #[test]
+    fn deserialize_empty_blobs() {
+        let json = r#"{"blobs":[]}"#;
+        let resp: EngineBlobsResponse = serde_json::from_str(json).unwrap();
+        assert!(resp.blobs.is_empty());
+    }
+}

--- a/src/api/types/fab_search.rs
+++ b/src/api/types/fab_search.rs
@@ -1,0 +1,427 @@
+use serde::{Deserialize, Serialize};
+
+/// Paginated search results from `GET /i/listings/search`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabSearchResults {
+    pub results: Vec<FabSearchListing>,
+    pub count: Option<u64>,
+    pub cursors: Option<FabSearchCursors>,
+    pub aggregations: Option<serde_json::Value>,
+}
+
+/// Pagination cursors for Fab search results.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabSearchCursors {
+    pub next: Option<String>,
+    pub previous: Option<String>,
+}
+
+/// A single listing in search results.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabSearchListing {
+    pub uid: String,
+    pub title: Option<String>,
+    pub listing_type: Option<String>,
+    pub user: Option<FabUser>,
+    pub category: Option<FabListingCategory>,
+    pub is_mature: Option<bool>,
+    pub is_free: Option<bool>,
+    pub is_discounted: Option<bool>,
+    pub published_at: Option<String>,
+    pub ratings: Option<serde_json::Value>,
+    pub starting_price: Option<serde_json::Value>,
+    pub tags: Option<Vec<FabTag>>,
+    pub thumbnails: Option<Vec<FabThumbnail>>,
+}
+
+/// Seller/user info within a listing.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabUser {
+    pub uid: Option<String>,
+    pub seller_name: Option<String>,
+    pub seller_id: Option<String>,
+    pub profile_url: Option<String>,
+    pub profile_image_url: Option<String>,
+    pub is_seller: Option<bool>,
+}
+
+/// Tag on a listing.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabTag {
+    pub name: Option<String>,
+    pub slug: Option<String>,
+    pub uid: Option<String>,
+}
+
+/// Thumbnail entry in a listing.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabThumbnail {
+    pub uid: Option<String>,
+    pub media_url: Option<String>,
+    #[serde(rename = "type")]
+    pub thumbnail_type: Option<String>,
+}
+
+/// Category in a listing (singular object, not array).
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabListingCategory {
+    pub uid: Option<String>,
+    pub name: Option<String>,
+    pub path: Option<String>,
+    pub slug: Option<String>,
+}
+
+/// Full listing detail from `GET /i/listings/{uid}`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabListingDetail {
+    pub uid: String,
+    pub title: Option<String>,
+    pub description: Option<String>,
+    pub listing_type: Option<String>,
+    pub user: Option<FabUser>,
+    pub category: Option<FabListingCategory>,
+    pub ratings: Option<serde_json::Value>,
+    pub is_mature: Option<bool>,
+    pub is_free: Option<bool>,
+    pub created_at: Option<String>,
+    pub published_at: Option<String>,
+    pub starting_price: Option<serde_json::Value>,
+    pub tags: Option<Vec<FabTag>>,
+    pub thumbnails: Option<Vec<FabThumbnail>>,
+    pub review_count: Option<u64>,
+}
+
+/// UE-specific asset format info from `GET /i/listings/{uid}/asset-formats/unreal-engine`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabListingUeFormat {
+    pub asset_format_type: Option<FabAssetFormatType>,
+    pub technical_specs: Option<FabTechnicalSpecs>,
+}
+
+/// Asset format type descriptor.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabAssetFormatType {
+    pub code: Option<String>,
+    pub icon: Option<String>,
+    pub name: Option<String>,
+}
+
+/// Technical specifications for a UE asset.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabTechnicalSpecs {
+    pub technical_details: Option<String>,
+    pub unreal_engine_engine_versions: Option<Vec<String>>,
+    pub unreal_engine_target_platforms: Option<Vec<String>>,
+    pub unreal_engine_distribution_method: Option<String>,
+}
+
+/// Bulk pricing response from `GET /i/listings/prices-infos`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabPriceInfo {
+    pub currency_code: Option<String>,
+    pub price: Option<f64>,
+    pub discount: Option<f64>,
+    pub vat: Option<f64>,
+}
+
+/// Ownership info from `GET /i/listings/{uid}/ownership`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabOwnership {
+    pub licenses: Option<Vec<FabLicense>>,
+}
+
+/// License type info.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabLicense {
+    pub name: Option<String>,
+    pub slug: Option<String>,
+}
+
+/// User listing state from `GET /i/users/me/listings-states/{uid}`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabListingState {
+    pub acquired: Option<bool>,
+    pub entitlement_id: Option<String>,
+    pub wishlisted: Option<bool>,
+    pub ownership: Option<serde_json::Value>,
+    pub review: Option<serde_json::Value>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deserialize_search_results_with_listings() {
+        let json = r#"{
+            "results": [
+                {
+                    "uid": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+                    "title": "Medieval Village Pack",
+                    "listingType": "3d-model",
+                    "user": {"sellerName": "Epic Marketplace", "uid": "seller-001", "isSeller": true},
+                    "category": {"uid": "cat-env", "name": "Environments", "path": "environments", "slug": "environments"},
+                    "isMature": false,
+                    "isFree": false,
+                    "publishedAt": "2025-06-15T10:30:00Z"
+                }
+            ],
+            "count": 142,
+            "cursors": {"next": "eyJwIjoyfQ==", "previous": null}
+        }"#;
+        let results: FabSearchResults = serde_json::from_str(json).unwrap();
+        assert_eq!(results.results.len(), 1);
+        assert_eq!(results.count, Some(142));
+        let listing = &results.results[0];
+        assert_eq!(listing.uid, "a1b2c3d4-e5f6-7890-abcd-ef1234567890");
+        assert_eq!(listing.title.as_deref(), Some("Medieval Village Pack"));
+        assert_eq!(listing.listing_type.as_deref(), Some("3d-model"));
+        assert_eq!(listing.is_mature, Some(false));
+        let user = listing.user.as_ref().unwrap();
+        assert_eq!(user.seller_name.as_deref(), Some("Epic Marketplace"));
+        assert_eq!(user.is_seller, Some(true));
+        let category = listing.category.as_ref().unwrap();
+        assert_eq!(category.name.as_deref(), Some("Environments"));
+        assert_eq!(category.slug.as_deref(), Some("environments"));
+        let cursors = results.cursors.as_ref().unwrap();
+        assert_eq!(cursors.next.as_deref(), Some("eyJwIjoyfQ=="));
+        assert!(cursors.previous.is_none());
+    }
+
+    #[test]
+    fn deserialize_search_results_empty() {
+        let json = r#"{"results": [], "count": 0}"#;
+        let results: FabSearchResults = serde_json::from_str(json).unwrap();
+        assert!(results.results.is_empty());
+        assert_eq!(results.count, Some(0));
+        assert!(results.cursors.is_none());
+    }
+
+    #[test]
+    fn deserialize_listing_detail() {
+        let json = r#"{
+            "uid": "listing-xyz-789",
+            "title": "Sci-Fi Weapon Set",
+            "description": "50 sci-fi weapons with PBR materials",
+            "listingType": "3d-model",
+            "user": {"sellerName": "GameArt Studio", "uid": "seller-042"},
+            "category": {"uid": "cat-weapons", "name": "Weapons", "path": "weapons", "slug": "weapons"},
+            "ratings": {"averageRating": 4.7, "total": 23},
+            "isMature": false,
+            "createdAt": "2025-03-01T00:00:00Z",
+            "publishedAt": "2025-03-01T00:00:00Z",
+            "reviewCount": 23
+        }"#;
+        let detail: FabListingDetail = serde_json::from_str(json).unwrap();
+        assert_eq!(detail.uid, "listing-xyz-789");
+        assert_eq!(detail.title.as_deref(), Some("Sci-Fi Weapon Set"));
+        let category = detail.category.as_ref().unwrap();
+        assert_eq!(category.name.as_deref(), Some("Weapons"));
+        assert!(detail.ratings.is_some());
+        assert_eq!(detail.review_count, Some(23));
+    }
+
+    #[test]
+    fn deserialize_ue_format() {
+        let json = r#"{
+            "assetFormatType": {"code": "ue-asset", "icon": "unreal-icon", "name": "Unreal Engine Asset"},
+            "technicalSpecs": {
+                "technicalDetails": "Verts: 12000, Tris: 8000",
+                "unrealEngineEngineVersions": ["5.3", "5.4", "5.5"],
+                "unrealEngineTargetPlatforms": ["Windows", "Linux", "Mac"],
+                "unrealEngineDistributionMethod": "asset-pack"
+            }
+        }"#;
+        let format: FabListingUeFormat = serde_json::from_str(json).unwrap();
+        let fmt_type = format.asset_format_type.as_ref().unwrap();
+        assert_eq!(fmt_type.code.as_deref(), Some("ue-asset"));
+        assert_eq!(fmt_type.name.as_deref(), Some("Unreal Engine Asset"));
+        let specs = format.technical_specs.as_ref().unwrap();
+        let versions = specs.unreal_engine_engine_versions.as_ref().unwrap();
+        assert_eq!(versions, &["5.3", "5.4", "5.5"]);
+        let platforms = specs.unreal_engine_target_platforms.as_ref().unwrap();
+        assert_eq!(platforms.len(), 3);
+        assert_eq!(
+            specs.unreal_engine_distribution_method.as_deref(),
+            Some("asset-pack")
+        );
+    }
+
+    #[test]
+    fn deserialize_price_info() {
+        let json = r#"{"currencyCode": "USD", "price": 29.99, "discount": 0.0, "vat": 0.0}"#;
+        let price: FabPriceInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(price.currency_code.as_deref(), Some("USD"));
+        assert_eq!(price.price, Some(29.99));
+        assert_eq!(price.discount, Some(0.0));
+    }
+
+    #[test]
+    fn deserialize_ownership_with_licenses() {
+        let json = r#"{"licenses": [{"name": "Standard License", "slug": "standard"}, {"name": "Enterprise", "slug": "enterprise"}]}"#;
+        let ownership: FabOwnership = serde_json::from_str(json).unwrap();
+        let licenses = ownership.licenses.as_ref().unwrap();
+        assert_eq!(licenses.len(), 2);
+        assert_eq!(licenses[0].name.as_deref(), Some("Standard License"));
+        assert_eq!(licenses[0].slug.as_deref(), Some("standard"));
+        assert_eq!(licenses[1].slug.as_deref(), Some("enterprise"));
+    }
+
+    #[test]
+    fn deserialize_ownership_empty() {
+        let json = r#"{"licenses": []}"#;
+        let ownership: FabOwnership = serde_json::from_str(json).unwrap();
+        assert!(ownership.licenses.as_ref().unwrap().is_empty());
+    }
+
+    #[test]
+    fn deserialize_listing_state() {
+        let json = r#"{"acquired": true, "entitlementId": "ent-abc-123", "wishlisted": false}"#;
+        let state: FabListingState = serde_json::from_str(json).unwrap();
+        assert_eq!(state.acquired, Some(true));
+        assert_eq!(state.entitlement_id.as_deref(), Some("ent-abc-123"));
+        assert_eq!(state.wishlisted, Some(false));
+        assert!(state.ownership.is_none());
+        assert!(state.review.is_none());
+    }
+
+    #[test]
+    fn search_params_default() {
+        let params = FabSearchParams::default();
+        assert!(params.channels.is_none());
+        assert!(params.listing_types.is_none());
+        assert!(params.sort_by.is_none());
+        assert!(params.count.is_none());
+        assert!(params.is_discounted.is_none());
+    }
+
+    #[test]
+    fn search_results_roundtrip() {
+        let results = FabSearchResults {
+            results: vec![FabSearchListing {
+                uid: "test-uid".to_string(),
+                title: Some("Test Asset".to_string()),
+                ..Default::default()
+            }],
+            count: Some(1),
+            cursors: Some(FabSearchCursors {
+                next: Some("cursor-abc".to_string()),
+                previous: None,
+            }),
+            aggregations: None,
+        };
+        let json = serde_json::to_string(&results).unwrap();
+        let roundtrip: FabSearchResults = serde_json::from_str(&json).unwrap();
+        assert_eq!(results, roundtrip);
+    }
+
+    #[test]
+    fn deserialize_real_api_search_result() {
+        let json = r#"{
+            "aggregations": null,
+            "cursors": {"next": "cD0yMDI2", "previous": null},
+            "results": [{
+                "uid": "a55fc08e-82ec-4332-8bed-dde44fff7847",
+                "title": "Steam Integration for Unreal Engine",
+                "listingType": "tool-and-plugin",
+                "isMature": false,
+                "isFree": false,
+                "isDiscounted": false,
+                "publishedAt": "2026-02-16T10:00:00Z",
+                "category": {"uid": "afd8c50c", "name": "Engine Tools", "path": "engine-tools", "slug": "engine-tools"},
+                "user": {"sellerName": "PloxTools", "sellerId": "o-hz52h7n", "uid": "86b03c21", "isSeller": true},
+                "ratings": {"averageRating": 0.0, "total": 0},
+                "tags": [{"name": "Steam", "slug": "steam", "uid": "tag-001"}],
+                "thumbnails": [{"uid": "thumb-001", "mediaUrl": "https://media.fab.com/img.jpg", "type": "thumbnail"}]
+            }]
+        }"#;
+        let results: FabSearchResults = serde_json::from_str(json).unwrap();
+        assert_eq!(results.results.len(), 1);
+        let listing = &results.results[0];
+        assert_eq!(listing.listing_type.as_deref(), Some("tool-and-plugin"));
+        assert_eq!(listing.is_free, Some(false));
+        let user = listing.user.as_ref().unwrap();
+        assert_eq!(user.seller_name.as_deref(), Some("PloxTools"));
+        let category = listing.category.as_ref().unwrap();
+        assert_eq!(category.name.as_deref(), Some("Engine Tools"));
+        let tags = listing.tags.as_ref().unwrap();
+        assert_eq!(tags[0].name.as_deref(), Some("Steam"));
+        let thumbs = listing.thumbnails.as_ref().unwrap();
+        assert_eq!(thumbs[0].thumbnail_type.as_deref(), Some("thumbnail"));
+    }
+
+    #[test]
+    fn deserialize_real_api_listing_detail() {
+        let json = r#"{
+            "uid": "a55fc08e-82ec-4332-8bed-dde44fff7847",
+            "title": "Steam Integration for Unreal Engine",
+            "description": "Integrates Steam SDK with Unreal Engine",
+            "listingType": "tool-and-plugin",
+            "isMature": false,
+            "isFree": false,
+            "createdAt": "2026-01-15T00:00:00Z",
+            "publishedAt": "2026-02-16T10:00:00Z",
+            "category": {"uid": "afd8c50c", "name": "Engine Tools", "path": "engine-tools", "slug": "engine-tools"},
+            "user": {"sellerName": "PloxTools", "uid": "86b03c21", "profileUrl": "https://www.fab.com/sellers/PloxTools"},
+            "ratings": {"rating5": 0, "total": 0},
+            "reviewCount": 0,
+            "startingPrice": {"price": 49.99, "offerId": "offer-001"}
+        }"#;
+        let detail: FabListingDetail = serde_json::from_str(json).unwrap();
+        assert_eq!(detail.uid, "a55fc08e-82ec-4332-8bed-dde44fff7847");
+        assert_eq!(detail.listing_type.as_deref(), Some("tool-and-plugin"));
+        assert_eq!(detail.review_count, Some(0));
+        let user = detail.user.as_ref().unwrap();
+        assert_eq!(user.seller_name.as_deref(), Some("PloxTools"));
+        assert_eq!(
+            user.profile_url.as_deref(),
+            Some("https://www.fab.com/sellers/PloxTools")
+        );
+    }
+}
+
+/// Search filter parameters for `fab_search()`.
+#[derive(Default, Debug, Clone)]
+pub struct FabSearchParams {
+    /// Channel filter (e.g. `unreal-engine`)
+    pub channels: Option<String>,
+    /// Listing type filter (e.g. `3d-model`, `tool-and-plugin`, `audio`, `material`)
+    pub listing_types: Option<String>,
+    /// Category filter
+    pub categories: Option<String>,
+    /// Sort order: `-relevance`, `-createdAt`, `createdAt`, `-price`, `price`
+    pub sort_by: Option<String>,
+    /// Results per page
+    pub count: Option<u32>,
+    /// Pagination cursor (from previous result)
+    pub cursor: Option<String>,
+    /// Aggregation type: `category_per_listing_type`, `channel`, `listing_type`
+    pub aggregate_on: Option<String>,
+    /// Filter to wishlisted items: set to `"wishlist"`
+    pub in_filter: Option<String>,
+    /// Only discounted items
+    pub is_discounted: Option<bool>,
+}

--- a/src/api/types/mod.rs
+++ b/src/api/types/mod.rs
@@ -66,3 +66,12 @@ pub mod uplay;
 
 /// Exchange Code structures
 pub mod exchange_code;
+
+/// Cosmos API types (session, account, EULA)
+pub mod cosmos;
+
+/// Engine version blob types
+pub mod engine_blob;
+
+/// Fab search and browse types
+pub mod fab_search;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,6 +109,9 @@ use api::types::service_status::ServiceStatus;
 use api::types::uplay::{
     UplayClaimResult, UplayCodesResult, UplayGraphQLResponse, UplayRedeemResult,
 };
+use api::types::cosmos;
+use api::types::engine_blob;
+use api::types::fab_search;
 use log::{error, info, warn};
 use crate::api::error::EpicAPIError;
 
@@ -920,6 +923,233 @@ impl EpicGames {
         uplay_account_id: &str,
     ) -> Result<UplayGraphQLResponse<UplayRedeemResult>, EpicAPIError> {
         self.egs.store_redeem_uplay_codes(uplay_account_id).await
+    }
+
+    // --- Cosmos Session ---
+
+    /// Set up a Cosmos cookie session from an exchange code.
+    /// Typically called with a code from `game_token()`.
+    pub async fn cosmos_session_setup(
+        &self,
+        exchange_code: &str,
+    ) -> Result<cosmos::CosmosAuthResponse, EpicAPIError> {
+        self.egs.cosmos_session_setup(exchange_code).await
+    }
+
+    /// Upgrade bearer token to Cosmos session (step 5 of session setup).
+    pub async fn cosmos_auth_upgrade(
+        &self,
+    ) -> Result<cosmos::CosmosAuthResponse, EpicAPIError> {
+        self.egs.cosmos_auth_upgrade().await
+    }
+
+    /// Check if a EULA has been accepted. Returns `None` on error.
+    pub async fn cosmos_eula_check(&self, eula_id: &str, locale: &str) -> Option<bool> {
+        self.egs
+            .cosmos_eula_check(eula_id, locale)
+            .await
+            .ok()
+            .map(|r| r.accepted)
+    }
+
+    /// Check if a EULA has been accepted. Returns full `Result`.
+    pub async fn try_cosmos_eula_check(
+        &self,
+        eula_id: &str,
+        locale: &str,
+    ) -> Result<cosmos::CosmosEulaResponse, EpicAPIError> {
+        self.egs.cosmos_eula_check(eula_id, locale).await
+    }
+
+    /// Accept a EULA. Returns `None` on error.
+    pub async fn cosmos_eula_accept(
+        &self,
+        eula_id: &str,
+        locale: &str,
+        version: u32,
+    ) -> Option<bool> {
+        self.egs
+            .cosmos_eula_accept(eula_id, locale, version)
+            .await
+            .ok()
+            .map(|r| r.accepted)
+    }
+
+    /// Accept a EULA. Returns full `Result`.
+    pub async fn try_cosmos_eula_accept(
+        &self,
+        eula_id: &str,
+        locale: &str,
+        version: u32,
+    ) -> Result<cosmos::CosmosEulaResponse, EpicAPIError> {
+        self.egs.cosmos_eula_accept(eula_id, locale, version).await
+    }
+
+    /// Get Cosmos account details. Returns `None` on error.
+    pub async fn cosmos_account(&self) -> Option<cosmos::CosmosAccount> {
+        self.egs.cosmos_account().await.ok()
+    }
+
+    /// Get Cosmos account details. Returns full `Result`.
+    pub async fn try_cosmos_account(&self) -> Result<cosmos::CosmosAccount, EpicAPIError> {
+        self.egs.cosmos_account().await
+    }
+
+    /// Fetch engine version download blobs for a platform. Returns `None` on error.
+    pub async fn engine_versions(
+        &self,
+        platform: &str,
+    ) -> Option<engine_blob::EngineBlobsResponse> {
+        self.egs.engine_versions(platform).await.ok()
+    }
+
+    /// Fetch engine version download blobs. Returns full `Result`.
+    pub async fn try_engine_versions(
+        &self,
+        platform: &str,
+    ) -> Result<engine_blob::EngineBlobsResponse, EpicAPIError> {
+        self.egs.engine_versions(platform).await
+    }
+
+    // --- Fab Search/Browse ---
+
+    /// Search Fab listings. Returns `None` on error.
+    pub async fn fab_search(
+        &self,
+        params: &fab_search::FabSearchParams,
+    ) -> Option<fab_search::FabSearchResults> {
+        self.egs.fab_search(params).await.ok()
+    }
+
+    /// Search Fab listings. Returns full `Result`.
+    pub async fn try_fab_search(
+        &self,
+        params: &fab_search::FabSearchParams,
+    ) -> Result<fab_search::FabSearchResults, EpicAPIError> {
+        self.egs.fab_search(params).await
+    }
+
+    /// Get full listing detail. Returns `None` on error.
+    pub async fn fab_listing(&self, uid: &str) -> Option<fab_search::FabListingDetail> {
+        self.egs.fab_listing(uid).await.ok()
+    }
+
+    /// Get full listing detail. Returns full `Result`.
+    pub async fn try_fab_listing(
+        &self,
+        uid: &str,
+    ) -> Result<fab_search::FabListingDetail, EpicAPIError> {
+        self.egs.fab_listing(uid).await
+    }
+
+    /// Get UE-specific format details for a listing. Returns `None` on error.
+    pub async fn fab_listing_ue_formats(
+        &self,
+        uid: &str,
+    ) -> Option<Vec<fab_search::FabListingUeFormat>> {
+        self.egs.fab_listing_ue_formats(uid).await.ok()
+    }
+
+    /// Get UE-specific format details. Returns full `Result`.
+    pub async fn try_fab_listing_ue_formats(
+        &self,
+        uid: &str,
+    ) -> Result<Vec<fab_search::FabListingUeFormat>, EpicAPIError> {
+        self.egs.fab_listing_ue_formats(uid).await
+    }
+
+    /// Get listing state (ownership, wishlist, review). Returns `None` on error.
+    pub async fn fab_listing_state(
+        &self,
+        uid: &str,
+    ) -> Option<fab_search::FabListingState> {
+        self.egs.fab_listing_state(uid).await.ok()
+    }
+
+    /// Get listing state. Returns full `Result`.
+    pub async fn try_fab_listing_state(
+        &self,
+        uid: &str,
+    ) -> Result<fab_search::FabListingState, EpicAPIError> {
+        self.egs.fab_listing_state(uid).await
+    }
+
+    /// Bulk check listing states. Returns `None` on error.
+    pub async fn fab_listing_states_bulk(
+        &self,
+        listing_ids: &[&str],
+    ) -> Option<Vec<fab_search::FabListingState>> {
+        self.egs.fab_listing_states_bulk(listing_ids).await.ok()
+    }
+
+    /// Bulk check listing states. Returns full `Result`.
+    pub async fn try_fab_listing_states_bulk(
+        &self,
+        listing_ids: &[&str],
+    ) -> Result<Vec<fab_search::FabListingState>, EpicAPIError> {
+        self.egs.fab_listing_states_bulk(listing_ids).await
+    }
+
+    /// Bulk fetch pricing for multiple offer IDs. Returns `None` on error.
+    pub async fn fab_bulk_prices(
+        &self,
+        offer_ids: &[&str],
+    ) -> Option<Vec<fab_search::FabPriceInfo>> {
+        self.egs.fab_bulk_prices(offer_ids).await.ok()
+    }
+
+    /// Bulk fetch pricing. Returns full `Result`.
+    pub async fn try_fab_bulk_prices(
+        &self,
+        offer_ids: &[&str],
+    ) -> Result<Vec<fab_search::FabPriceInfo>, EpicAPIError> {
+        self.egs.fab_bulk_prices(offer_ids).await
+    }
+
+    /// Get listing ownership info. Returns `None` on error.
+    pub async fn fab_listing_ownership(
+        &self,
+        uid: &str,
+    ) -> Option<fab_search::FabOwnership> {
+        self.egs.fab_listing_ownership(uid).await.ok()
+    }
+
+    /// Get listing ownership info. Returns full `Result`.
+    pub async fn try_fab_listing_ownership(
+        &self,
+        uid: &str,
+    ) -> Result<fab_search::FabOwnership, EpicAPIError> {
+        self.egs.fab_listing_ownership(uid).await
+    }
+
+    // --- Cosmos Policy/Communication ---
+
+    /// Check Age of Digital Consent policy. Returns `None` on error.
+    pub async fn cosmos_policy_aodc(&self) -> Option<cosmos::CosmosPolicyAodc> {
+        self.egs.cosmos_policy_aodc().await.ok()
+    }
+
+    /// Check Age of Digital Consent policy. Returns full `Result`.
+    pub async fn try_cosmos_policy_aodc(
+        &self,
+    ) -> Result<cosmos::CosmosPolicyAodc, EpicAPIError> {
+        self.egs.cosmos_policy_aodc().await
+    }
+
+    /// Check communication opt-in status. Returns `None` on error.
+    pub async fn cosmos_comm_opt_in(
+        &self,
+        setting: &str,
+    ) -> Option<cosmos::CosmosCommOptIn> {
+        self.egs.cosmos_comm_opt_in(setting).await.ok()
+    }
+
+    /// Check communication opt-in status. Returns full `Result`.
+    pub async fn try_cosmos_comm_opt_in(
+        &self,
+        setting: &str,
+    ) -> Result<cosmos::CosmosCommOptIn, EpicAPIError> {
+        self.egs.cosmos_comm_opt_in(setting).await
     }
 }
 


### PR DESCRIPTION
## Summary

Adds three new API surface areas to the crate, bumps version to **0.11.0**.

### Cosmos Session (unrealengine.com)
- Cookie-based session setup from exchange codes
- EULA check and accept
- Account details, Age of Digital Consent policy, communication opt-in

### Fab Search & Browse
- Search/browse listings with filters (channels, listing types, categories, sorting, pagination)
- Full listing detail with seller, category, ratings, thumbnails
- UE-specific format specs (engine versions, target platforms, distribution method)
- Listing state (ownership, wishlist, review), bulk states, bulk pricing, ownership/licenses
- Types aligned to real Fab API response shapes (validated against live `fab.com/i/listings/search`)

### Engine Version Blobs
- Per-platform engine version listing with download details

### Infrastructure
- New `get_json()` HTTP helper for unauthenticated GET→JSON requests
- 32 new facade methods on `EpicGames` (`Option` + `Result` variants)
- 12 new serde tests for Fab search types, 6 for Cosmos types, 2 for engine blobs
- New `cosmos` example, expanded `fab` example with search/browse/detail demo
- README updated with new API tables and architecture diagram

**106 tests passing**, all examples compile clean.