### PR TITLE
Add Fab marketplace filters, listing formats, and add-to-library endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egs-api"
-version = "0.12.0"
+version = "0.13.0"
 authors = ["Milan Šťastný <milan@acheta.games>"]
 description = "Interface to the Epic Games API"
 categories = ["api-bindings", "asynchronous", "games"]

--- a/examples/fab.rs
+++ b/examples/fab.rs
@@ -246,11 +246,15 @@ async fn main() {
                                     .price
                                     .map(|p| format!("{:.2}", p))
                                     .unwrap_or_else(|| "N/A".to_string());
-                                let discount = price.discount.unwrap_or(0.0);
-                                if discount > 0.0 {
+                                let discount_pct = price.discount_percentage.unwrap_or(0);
+                                if discount_pct > 0 {
+                                    let discounted = price
+                                        .discounted_price
+                                        .map(|p| format!("{:.2}", p))
+                                        .unwrap_or_else(|| "N/A".to_string());
                                     println!(
-                                        "  {} {} (discount: {:.0}%)",
-                                        currency, amount, discount
+                                        "  {} {} → {} ({}% off)",
+                                        currency, amount, discounted, discount_pct
                                     );
                                 } else {
                                     println!("  {} {}", currency, amount);

--- a/src/api/fab.rs
+++ b/src/api/fab.rs
@@ -190,6 +190,17 @@ impl EpicAPI {
                 query_parts.push("is_discounted=true".to_string());
             }
         }
+        if let Some(is_free) = params.is_free {
+            if is_free {
+                query_parts.push("is_free=1".to_string());
+            }
+        }
+        if let Some(pct) = params.min_discount_percentage {
+            query_parts.push(format!("min_discount_percentage={}", pct));
+        }
+        if let Some(ref seller) = params.seller {
+            query_parts.push(format!("seller={}", seller));
+        }
 
         url.push_str(&query_parts.join("&"));
         self.get_json(&url).await
@@ -242,7 +253,7 @@ impl EpicAPI {
     pub async fn fab_bulk_prices(
         &self,
         offer_ids: &[&str],
-    ) -> Result<Vec<crate::api::types::fab_search::FabPriceInfo>, EpicAPIError> {
+    ) -> Result<crate::api::types::fab_search::FabBulkPricesResponse, EpicAPIError> {
         let ids = offer_ids
             .iter()
             .map(|id| format!("offer_ids={}", id))
@@ -408,5 +419,44 @@ impl EpicAPI {
         &self,
     ) -> Result<crate::api::types::fab_search::FabUserContext, EpicAPIError> {
         self.get_json("https://www.fab.com/i/users/context").await
+    }
+
+    /// Add a free listing to the user's library. Returns `Ok(())` on success (HTTP 204).
+    pub async fn fab_add_to_library(&self, listing_uid: &str) -> Result<(), EpicAPIError> {
+        let url = format!(
+            "https://www.fab.com/i/listings/{}/add-to-library",
+            listing_uid
+        );
+        let parsed_url = Url::parse(&url).map_err(|_| EpicAPIError::InvalidParams)?;
+        let response = self
+            .authorized_post_client(parsed_url)
+            .send()
+            .await
+            .map_err(|e| {
+                error!("{:?}", e);
+                EpicAPIError::NetworkError(e)
+            })?;
+        if response.status() == reqwest::StatusCode::NO_CONTENT
+            || response.status() == reqwest::StatusCode::OK
+        {
+            Ok(())
+        } else {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            warn!("{} result: {}", status, body);
+            Err(EpicAPIError::HttpError { status, body })
+        }
+    }
+
+    /// Fetch all available asset formats for a listing (UE, Unity, FBX, Blender, etc.).
+    pub async fn fab_listing_formats(
+        &self,
+        listing_uid: &str,
+    ) -> Result<Vec<crate::api::types::fab_search::FabListingFormat>, EpicAPIError> {
+        let url = format!(
+            "https://www.fab.com/i/listings/{}/asset-formats",
+            listing_uid
+        );
+        self.authorized_get_json(&url).await
     }
 }

--- a/src/api/types/fab_search.rs
+++ b/src/api/types/fab_search.rs
@@ -137,10 +137,24 @@ pub struct FabTechnicalSpecs {
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FabPriceInfo {
+    pub offer_id: Option<String>,
     pub currency_code: Option<String>,
     pub price: Option<f64>,
-    pub discount: Option<f64>,
+    pub discounted_price: Option<f64>,
+    pub discount_percentage: Option<u32>,
+    pub effective_discount_percentage: Option<u32>,
+    pub discount_start_date: Option<String>,
+    pub discount_end_date: Option<String>,
+    pub lowest_prior_price: Option<f64>,
     pub vat: Option<f64>,
+    pub vat_rate: Option<f64>,
+}
+
+/// Wrapper for bulk pricing response from `GET /i/listings/prices-infos?offer_ids=...`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabBulkPricesResponse {
+    pub offers: Vec<FabPriceInfo>,
 }
 
 /// Ownership info from `GET /i/listings/{uid}/ownership`.
@@ -272,11 +286,35 @@ mod tests {
 
     #[test]
     fn deserialize_price_info() {
-        let json = r#"{"currencyCode": "USD", "price": 29.99, "discount": 0.0, "vat": 0.0}"#;
+        let json = r#"{"offerId": "abc123", "currencyCode": "USD", "price": 29.99, "discountedPrice": 29.99, "vat": 0.0, "vatRate": 0.21}"#;
         let price: FabPriceInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(price.offer_id.as_deref(), Some("abc123"));
         assert_eq!(price.currency_code.as_deref(), Some("USD"));
         assert_eq!(price.price, Some(29.99));
-        assert_eq!(price.discount, Some(0.0));
+        assert_eq!(price.discounted_price, Some(29.99));
+        assert_eq!(price.vat_rate, Some(0.21));
+    }
+
+    #[test]
+    fn deserialize_price_info_with_discount() {
+        let json = r#"{
+            "offerId": "offer-disc",
+            "currencyCode": "CZK",
+            "price": 1238.42,
+            "discountedPrice": 0.0,
+            "discountPercentage": 100,
+            "effectiveDiscountPercentage": 100,
+            "discountStartDate": "2026-02-10T15:00:00.000Z",
+            "discountEndDate": "2026-02-24T14:59:00.000Z",
+            "lowestPriorPrice": 866.81,
+            "vat": 0.0,
+            "vatRate": 0.21
+        }"#;
+        let price: FabPriceInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(price.discount_percentage, Some(100));
+        assert_eq!(price.discounted_price, Some(0.0));
+        assert_eq!(price.lowest_prior_price, Some(866.81));
+        assert!(price.discount_end_date.is_some());
     }
 
     #[test]
@@ -317,6 +355,46 @@ mod tests {
         assert!(params.sort_by.is_none());
         assert!(params.count.is_none());
         assert!(params.is_discounted.is_none());
+        assert!(params.is_free.is_none());
+        assert!(params.min_discount_percentage.is_none());
+        assert!(params.seller.is_none());
+    }
+
+    #[test]
+    fn deserialize_listing_formats() {
+        let json = r#"[
+            {
+                "assetFormatType": {"code": "unreal-engine", "icon": "unreal-engine", "name": "Unreal Engine"},
+                "files": [{"uid": "file-001", "name": "MyAsset V1", "fileSize": 3444643477}]
+            },
+            {
+                "assetFormatType": {"code": "fbx", "icon": "cube", "name": "FBX"},
+                "files": [{"uid": "file-002", "name": "myasset.zip", "fileSize": 1234567}]
+            }
+        ]"#;
+        let formats: Vec<FabListingFormat> = serde_json::from_str(json).unwrap();
+        assert_eq!(formats.len(), 2);
+        let ue = &formats[0];
+        assert_eq!(
+            ue.asset_format_type.as_ref().unwrap().code.as_deref(),
+            Some("unreal-engine")
+        );
+        let files = ue.files.as_ref().unwrap();
+        assert_eq!(files[0].uid.as_deref(), Some("file-001"));
+        assert_eq!(files[0].file_size, Some(3444643477));
+        let fbx = &formats[1];
+        assert_eq!(
+            fbx.asset_format_type.as_ref().unwrap().code.as_deref(),
+            Some("fbx")
+        );
+    }
+
+    #[test]
+    fn deserialize_listing_formats_empty_files() {
+        let json = r#"[{"assetFormatType": {"code": "blender", "name": "Blender"}, "files": []}]"#;
+        let formats: Vec<FabListingFormat> = serde_json::from_str(json).unwrap();
+        assert_eq!(formats.len(), 1);
+        assert!(formats[0].files.as_ref().unwrap().is_empty());
     }
 
     #[test]
@@ -541,4 +619,33 @@ pub struct FabSearchParams {
     pub in_filter: Option<String>,
     /// Only discounted items
     pub is_discounted: Option<bool>,
+    /// Only free items
+    pub is_free: Option<bool>,
+    /// Minimum discount percentage (e.g. `1` for any discount, `50` for 50%+ off)
+    pub min_discount_percentage: Option<u32>,
+    /// Filter by seller name
+    pub seller: Option<String>,
+}
+
+/// All available asset formats for a listing from `GET /i/listings/{uid}/asset-formats`.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabListingFormat {
+    pub asset_format_type: Option<FabAssetFormatType>,
+    pub files: Option<Vec<FabFormatFile>>,
+}
+
+/// A downloadable file within a listing format.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FabFormatFile {
+    pub uid: Option<String>,
+    pub name: Option<String>,
+    pub file_size: Option<u64>,
+    pub asset_type: Option<String>,
+    pub platforms_included: Option<Vec<String>>,
+    pub initial_engine_version: Option<String>,
+    pub engine_versions: Option<Vec<String>>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1097,7 +1097,7 @@ impl EpicGames {
     pub async fn fab_bulk_prices(
         &self,
         offer_ids: &[&str],
-    ) -> Option<Vec<fab_search::FabPriceInfo>> {
+    ) -> Option<fab_search::FabBulkPricesResponse> {
         self.egs.fab_bulk_prices(offer_ids).await.ok()
     }
 
@@ -1105,7 +1105,7 @@ impl EpicGames {
     pub async fn try_fab_bulk_prices(
         &self,
         offer_ids: &[&str],
-    ) -> Result<Vec<fab_search::FabPriceInfo>, EpicAPIError> {
+    ) -> Result<fab_search::FabBulkPricesResponse, EpicAPIError> {
         self.egs.fab_bulk_prices(offer_ids).await
     }
 
@@ -1257,6 +1257,27 @@ impl EpicGames {
         &self,
     ) -> Result<fab_search::FabUserContext, EpicAPIError> {
         self.egs.fab_user_context().await
+    }
+
+    /// Add a free listing to the user's library. Returns `Ok(())` on success.
+    pub async fn fab_add_to_library(&self, listing_uid: &str) -> Result<(), EpicAPIError> {
+        self.egs.fab_add_to_library(listing_uid).await
+    }
+
+    /// Fetch all available asset formats for a listing. Returns `None` on error.
+    pub async fn fab_listing_formats(
+        &self,
+        listing_uid: &str,
+    ) -> Option<Vec<fab_search::FabListingFormat>> {
+        self.egs.fab_listing_formats(listing_uid).await.ok()
+    }
+
+    /// Fetch all available asset formats. Returns full `Result`.
+    pub async fn try_fab_listing_formats(
+        &self,
+        listing_uid: &str,
+    ) -> Result<Vec<fab_search::FabListingFormat>, EpicAPIError> {
+        self.egs.fab_listing_formats(listing_uid).await
     }
 
     // --- Cosmos Policy/Communication ---


### PR DESCRIPTION
## Summary

Adds new Fab marketplace API capabilities discovered via MITM analysis of the fab.com web client, bumps to 0.13.0.

### New Endpoints
- **`fab_add_to_library(uid)`** — `POST /i/listings/{uid}/add-to-library` — Claims a free listing to the user's library (HTTP 204 on success)
- **`fab_listing_formats(uid)`** — `GET /i/listings/{uid}/asset-formats` — Returns all available download formats (UE, Unity, FBX, Blender, etc.) with file UIDs and sizes

### New Search Parameters
Added to `FabSearchParams` and wired through `fab_search()`:
- `is_free: Option<bool>` — Filter to free-only listings
- `min_discount_percentage: Option<u32>` — Filter by minimum discount (e.g. `1` = any discount)
- `seller: Option<String>` — Filter by seller name

### Enriched Types
- **`FabPriceInfo`** — Expanded from 4 to 11 fields matching actual API response: `offer_id`, `discounted_price`, `discount_percentage`, `effective_discount_percentage`, `discount_start_date`, `discount_end_date`, `lowest_prior_price`, `vat_rate`
- **`FabBulkPricesResponse`** — New wrapper for bulk prices endpoint (`{"offers": [...]}`)
- **`FabListingFormat`** + **`FabFormatFile`** — New types for the all-formats endpoint

### Breaking Changes
- `fab_bulk_prices()` now returns `FabBulkPricesResponse` instead of `Vec<FabPriceInfo>` (access via `.offers`)
- `FabPriceInfo.discount` field renamed/replaced with `discount_percentage`, `discounted_price` etc.