### PR TITLE
fix: improve deserialization logging and fix /i/tags/groups parsing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egs-api"
-version = "0.13.0"
+version = "0.13.1"
 authors = ["Milan Šťastný <milan@acheta.games>"]
 description = "Interface to the Epic Games API"
 categories = ["api-bindings", "asynchronous", "games"]

--- a/src/api/fab.rs
+++ b/src/api/fab.rs
@@ -325,7 +325,10 @@ impl EpicAPI {
     pub async fn fab_tag_groups(
         &self,
     ) -> Result<Vec<crate::api::types::fab_taxonomy::FabTagGroup>, EpicAPIError> {
-        self.get_json("https://www.fab.com/i/tags/groups").await
+        let wrapper: crate::api::types::fab_taxonomy::FabResultsWrapper<
+            crate::api::types::fab_taxonomy::FabTagGroup,
+        > = self.get_json("https://www.fab.com/i/tags/groups").await?;
+        Ok(wrapper.results)
     }
 
     /// Fetch available UE versions. Public endpoint.

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -1,4 +1,4 @@
-use log::{error, warn};
+use log::{debug, error, warn};
 use reqwest::header::HeaderMap;
 use reqwest::{Client, RequestBuilder};
 use serde::de::DeserializeOwned;
@@ -116,6 +116,7 @@ impl EpicAPI {
         url: &str,
     ) -> Result<T, EpicAPIError> {
         let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        debug!("authorized_get_json: {}", url);
         let response = self
             .authorized_get_client(parsed_url)
             .send()
@@ -125,8 +126,13 @@ impl EpicAPI {
                 EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK {
-            response.json::<T>().await.map_err(|e| {
-                error!("{:?}", e);
+            let body = response.text().await.map_err(|e| {
+                error!("Failed to read response body from {}: {:?}", url, e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })?;
+            serde_json::from_str::<T>(&body).map_err(|e| {
+                error!("Deserialization failed for {}: {:?}", url, e);
+                error!("Response body: {}", &body[..body.len().min(2048)]);
                 EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {
@@ -144,6 +150,7 @@ impl EpicAPI {
         form: &[(String, String)],
     ) -> Result<T, EpicAPIError> {
         let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        debug!("authorized_post_form_json: {}", url);
         let response = self
             .authorized_post_client(parsed_url)
             .form(form)
@@ -154,8 +161,13 @@ impl EpicAPI {
                 EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK {
-            response.json::<T>().await.map_err(|e| {
-                error!("{:?}", e);
+            let body = response.text().await.map_err(|e| {
+                error!("Failed to read response body from {}: {:?}", url, e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })?;
+            serde_json::from_str::<T>(&body).map_err(|e| {
+                error!("Deserialization failed for {}: {:?}", url, e);
+                error!("Response body: {}", &body[..body.len().min(2048)]);
                 EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {
@@ -173,6 +185,7 @@ impl EpicAPI {
         body: &B,
     ) -> Result<T, EpicAPIError> {
         let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        debug!("authorized_post_json: {}", url);
         let response = self
             .authorized_post_client(parsed_url)
             .json(body)
@@ -183,8 +196,13 @@ impl EpicAPI {
                 EpicAPIError::NetworkError(e)
             })?;
         if response.status() == reqwest::StatusCode::OK {
-            response.json::<T>().await.map_err(|e| {
-                error!("{:?}", e);
+            let resp_body = response.text().await.map_err(|e| {
+                error!("Failed to read response body from {}: {:?}", url, e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })?;
+            serde_json::from_str::<T>(&resp_body).map_err(|e| {
+                error!("Deserialization failed for {}: {:?}", url, e);
+                error!("Response body: {}", &resp_body[..resp_body.len().min(2048)]);
                 EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {
@@ -226,13 +244,19 @@ impl EpicAPI {
         url: &str,
     ) -> Result<T, EpicAPIError> {
         let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
+        debug!("get_json: {}", url);
         let response = self.client.get(parsed_url).send().await.map_err(|e| {
             error!("{:?}", e);
             EpicAPIError::NetworkError(e)
         })?;
         if response.status() == reqwest::StatusCode::OK {
-            response.json::<T>().await.map_err(|e| {
-                error!("{:?}", e);
+            let body = response.text().await.map_err(|e| {
+                error!("Failed to read response body from {}: {:?}", url, e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })?;
+            serde_json::from_str::<T>(&body).map_err(|e| {
+                error!("Deserialization failed for {}: {:?}", url, e);
+                error!("Response body: {}", &body[..body.len().min(2048)]);
                 EpicAPIError::DeserializationError(format!("{}", e))
             })
         } else {

--- a/src/api/types/fab_taxonomy.rs
+++ b/src/api/types/fab_taxonomy.rs
@@ -24,9 +24,19 @@ pub struct FabFormatGroup {
 #[allow(missing_docs)]
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct FabTagGroup {
+    pub category: Option<String>,
     pub name: Option<String>,
+    pub order: Option<i32>,
     pub slug: Option<String>,
     pub tags: Option<Vec<FabTag>>,
+    pub uid: Option<String>,
+}
+
+/// Paginated wrapper returned by Fab API endpoints.
+#[allow(missing_docs)]
+#[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FabResultsWrapper<T> {
+    pub results: Vec<T>,
 }
 
 /// Channel info from `GET /i/channels/{slug}`.
@@ -73,18 +83,35 @@ mod tests {
     #[test]
     fn deserialize_tag_group() {
         let json = r#"{
-            "name": "Style",
-            "slug": "style",
+            "category": "style",
+            "name": "Rendering Style",
+            "order": 0,
+            "slug": "rendering-style",
             "tags": [
                 {"name": "Realistic", "slug": "realistic", "uid": "tag-1"},
                 {"name": "Stylized", "slug": "stylized", "uid": "tag-2"}
-            ]
+            ],
+            "uid": "group-1"
         }"#;
         let group: FabTagGroup = serde_json::from_str(json).unwrap();
-        assert_eq!(group.name, Some("Style".to_string()));
+        assert_eq!(group.category, Some("style".to_string()));
+        assert_eq!(group.name, Some("Rendering Style".to_string()));
+        assert_eq!(group.order, Some(0));
         let tags = group.tags.unwrap();
         assert_eq!(tags.len(), 2);
         assert_eq!(tags[0].name, Some("Realistic".to_string()));
+    }
+
+    #[test]
+    fn deserialize_tag_group_results_wrapper() {
+        let json = r#"{"results": [
+            {"category": "style", "name": "Style", "slug": "style", "order": 0, "tags": [], "uid": "g1"},
+            {"category": "theme", "name": "Theme", "slug": "theme", "order": 1, "tags": [], "uid": "g2"}
+        ]}"#;
+        let wrapper: FabResultsWrapper<FabTagGroup> = serde_json::from_str(json).unwrap();
+        assert_eq!(wrapper.results.len(), 2);
+        assert_eq!(wrapper.results[0].slug, Some("style".to_string()));
+        assert_eq!(wrapper.results[1].slug, Some("theme".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Deserialization error logging**: All JSON-deserializing methods now read the response as text first and log the URL + first 2048 bytes of the response body on failure. This makes it possible to diagnose API changes without a debugger.
- **Fix `/i/tags/groups` deserialization**: The Fab endpoint returns `{"results": [...]}` but `fab_tag_groups()` was deserializing directly as `Vec<FabTagGroup>`, causing `invalid type: map, expected a sequence` errors. Added `FabResultsWrapper<T>` to unwrap the results.
- **Add missing fields to `FabTagGroup`**: `category`, `order`, and `uid` fields now captured from the API response.
- **Version bump**: 0.13.0 → 0.13.1