### PR TITLE
ci: upgrade workflow with clippy, rustfmt, MSRV matrix, cache, and publish

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Pre-commit hook: run rustfmt on staged .rs files
+# Install: git config core.hooksPath .githooks
+
+# Get staged .rs files (only added/modified, not deleted)
+STAGED=$(git diff --cached --name-only --diff-filter=AM | grep '\.rs$')
+
+if [ -z "$STAGED" ]; then
+    exit 0
+fi
+
+# Check if rustfmt is available
+if ! command -v rustfmt >/dev/null 2>&1; then
+    echo "rustfmt not found. Install with: rustup component add rustfmt"
+    exit 1
+fi
+
+# Run rustfmt --check on staged files
+UNFORMATTED=""
+for file in $STAGED; do
+    if ! rustfmt --edition 2024 --check "$file" >/dev/null 2>&1; then
+        UNFORMATTED="$UNFORMATTED $file"
+    fi
+done
+
+if [ -n "$UNFORMATTED" ]; then
+    echo "rustfmt: the following files need formatting:"
+    for file in $UNFORMATTED; do
+        echo "  $file"
+    done
+    echo ""
+    echo "Run 'cargo fmt' to fix, then re-stage."
+    exit 1
+fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,23 +1,59 @@
-name: Rust
+name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [master]
   pull_request:
-    types: [assigned, opened, synchronize, reopened]
   workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  check:
+    name: Check
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: cargo build --lib
-    - name: Run tests
-      run: cargo test --tests --lib
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build
+        run: cargo build --lib
+      - name: Run tests
+        run: cargo test --tests --lib
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Clippy
+        run: cargo clippy --lib --tests -- -D warnings
+
+  fmt:
+    name: Rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt -- --check
+
+  publish:
+    name: Publish to crates.io
+    needs: [check, clippy, fmt]
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Publish
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,7 @@ license = "MIT"
 readme = "README.md"
 repository = "https://github.com/AchetaGames/egs-api-rs"
 documentation = "https://docs.rs/egs-api/latest/egs_api/"
-edition = "2021"
-rust-version = "1.82"
+edition = "2024"
 autoexamples = false
 
 [dependencies]

--- a/examples/account.rs
+++ b/examples/account.rs
@@ -61,11 +61,7 @@ async fn main() {
         Some(auths) => {
             println!("Linked platforms: {}", auths.len());
             for auth in &auths {
-                println!(
-                    "  {} - {}",
-                    auth.type_field,
-                    auth.external_display_name
-                );
+                println!("  {} - {}", auth.type_field, auth.external_display_name);
             }
         }
         None => eprintln!("Failed to fetch external auth connections"),

--- a/examples/assets.rs
+++ b/examples/assets.rs
@@ -71,10 +71,7 @@ async fn main() {
                 );
             }
         }
-        None => eprintln!(
-            "Failed to fetch asset manifest for {}",
-            test_asset.app_name
-        ),
+        None => eprintln!("Failed to fetch asset manifest for {}", test_asset.app_name),
     }
 
     println!("\n=== Artifact Service Ticket ===\n");

--- a/examples/auth.rs
+++ b/examples/auth.rs
@@ -40,7 +40,10 @@ async fn main() {
     }
 
     let details = egs.user_details();
-    println!("\nLogged in as: {}", details.display_name.unwrap_or_default());
+    println!(
+        "\nLogged in as: {}",
+        details.display_name.unwrap_or_default()
+    );
     println!("Account ID: {}", details.account_id.unwrap_or_default());
 
     println!("\nToken saved. Run other examples without re-authenticating.");

--- a/examples/client_credentials.rs
+++ b/examples/client_credentials.rs
@@ -18,9 +18,7 @@ async fn main() {
     let mut client_egs = EpicGames::new();
     if client_egs.auth_client_credentials().await {
         println!("Client credentials auth succeeded");
-        println!(
-            "Token type: client_credentials (limited permissions, no user context)"
-        );
+        println!("Token type: client_credentials (limited permissions, no user context)");
     } else {
         eprintln!("Client credentials auth failed");
         return;
@@ -31,6 +29,9 @@ async fn main() {
     let test_token = "test-token-id";
     match egs.library_state_token_status(test_token).await {
         Some(valid) => println!("Token '{}' valid: {}", test_token, valid),
-        None => println!("Token '{}': could not check status (API error or invalid)", test_token),
+        None => println!(
+            "Token '{}': could not check status (API error or invalid)",
+            test_token
+        ),
     }
 }

--- a/examples/cloud_saves.rs
+++ b/examples/cloud_saves.rs
@@ -33,9 +33,15 @@ async fn main() {
             if let Some((path, file)) = response.files.iter().next() {
                 println!("\n=== Cloud Save Details (first file) ===\n");
                 println!("  Path:       {}", path);
-                println!("  Filename:   {}", file.file_name.as_deref().unwrap_or("N/A"));
+                println!(
+                    "  Filename:   {}",
+                    file.file_name.as_deref().unwrap_or("N/A")
+                );
                 println!("  Length:     {} bytes", file.length.unwrap_or(0));
-                println!("  Storage:    {}", file.storage_type.as_deref().unwrap_or("N/A"));
+                println!(
+                    "  Storage:    {}",
+                    file.storage_type.as_deref().unwrap_or("N/A")
+                );
                 println!("  ETag:       {}", file.etag.as_deref().unwrap_or("N/A"));
                 if let Some(link) = &file.read_link {
                     println!("  Read link:  {}...", &link[..link.len().min(80)]);
@@ -54,11 +60,7 @@ async fn main() {
             Ok(response) => {
                 println!("  Files: {}", response.files.len());
                 for (path, file) in response.files.iter().take(5) {
-                    println!(
-                        "    {} — {} bytes",
-                        path,
-                        file.length.unwrap_or(0),
-                    );
+                    println!("    {} — {} bytes", path, file.length.unwrap_or(0),);
                 }
             }
             Err(e) => eprintln!("  No cloud saves or error: {:?}", e),

--- a/examples/compare_manifests.rs
+++ b/examples/compare_manifests.rs
@@ -27,7 +27,10 @@ async fn main() {
     println!("Total EGS assets: {}", assets.len());
 
     if let Some(asset) = assets.first() {
-        println!("Using asset: {} ({})", asset.app_name, asset.catalog_item_id);
+        println!(
+            "Using asset: {} ({})",
+            asset.app_name, asset.catalog_item_id
+        );
 
         if let Some(manifest) = egs
             .asset_manifest(
@@ -71,8 +74,11 @@ async fn main() {
                 println!("Using Fab item: {:?}\n", item);
 
                 // Use the Kite Demo as a known-good test asset, or fall back to first item
-                let (artifact_id, namespace, asset_id) =
-                    ("KiteDemo473", "89efe5924d3d467c839449ab6ab52e7f", "28166226c38a4ff3aa28bbe87dcbbe5b");
+                let (artifact_id, namespace, asset_id) = (
+                    "KiteDemo473",
+                    "89efe5924d3d467c839449ab6ab52e7f",
+                    "28166226c38a4ff3aa28bbe87dcbbe5b",
+                );
 
                 println!("Fetching Fab manifest for artifact: {}", artifact_id);
 
@@ -84,7 +90,10 @@ async fn main() {
                         println!("Got {} download info(s)", download_infos.len());
 
                         if let Some(info) = download_infos.first() {
-                            println!("Distribution point base URLs: {:?}", info.distribution_point_base_urls);
+                            println!(
+                                "Distribution point base URLs: {:?}",
+                                info.distribution_point_base_urls
+                            );
 
                             if let Some(base_url) = info.distribution_point_base_urls.first() {
                                 match egs.fab_download_manifest(info.clone(), base_url).await {
@@ -111,13 +120,20 @@ async fn main() {
     }
 }
 
-fn print_manifest_summary(label: &str, dm: &egs_api::api::types::download_manifest::DownloadManifest) {
+fn print_manifest_summary(
+    label: &str,
+    dm: &egs_api::api::types::download_manifest::DownloadManifest,
+) {
     println!("[{}] App name:      {}", label, dm.app_name_string);
     println!("[{}] Build version: {}", label, dm.build_version_string);
     println!("[{}] Files:         {}", label, dm.file_manifest_list.len());
     println!("[{}] Chunks:        {}", label, dm.chunk_hash_list.len());
     println!("[{}] Total size:    {} bytes", label, dm.total_size());
-    println!("[{}] Download size: {} bytes", label, dm.total_download_size());
+    println!(
+        "[{}] Download size: {} bytes",
+        label,
+        dm.total_download_size()
+    );
 
     // Custom fields — the key comparison point
     println!("\n[{}] Custom fields:", label);
@@ -169,10 +185,16 @@ fn print_manifest_summary(label: &str, dm: &egs_api::api::types::download_manife
     println!("  Files with chunk links:     {}", files_with_links);
     println!("  Files WITHOUT chunk links:  {}", files_without_links);
     println!("  Total chunk parts w/ link:  {}", total_chunks_with_links);
-    println!("  Total chunk parts NO link:  {}", total_chunks_without_links);
+    println!(
+        "  Total chunk parts NO link:  {}",
+        total_chunks_without_links
+    );
 
     if total_chunks_without_links > 0 {
-        println!("\n  *** WARNING: {} chunk parts have no download URL! Downloads will fail. ***", total_chunks_without_links);
+        println!(
+            "\n  *** WARNING: {} chunk parts have no download URL! Downloads will fail. ***",
+            total_chunks_without_links
+        );
     } else if total_chunks_with_links > 0 {
         println!("\n  All chunk parts have valid download URLs.");
     }
@@ -194,7 +216,11 @@ fn print_manifest_summary(label: &str, dm: &egs_api::api::types::download_manife
             println!(
                 "\n[{}] Sample: file={}, chunk_guid={}, url={}",
                 label,
-                if filename.len() > 60 { &filename[..60] } else { filename },
+                if filename.len() > 60 {
+                    &filename[..60]
+                } else {
+                    filename
+                },
                 part.guid,
                 url_display
             );

--- a/examples/fab.rs
+++ b/examples/fab.rs
@@ -1,8 +1,8 @@
 #[path = "common.rs"]
 mod common;
 
-use egs_api::api::types::fab_search::FabSearchParams;
 use egs_api::EpicGames;
+use egs_api::api::types::fab_search::FabSearchParams;
 
 #[tokio::main]
 async fn main() {
@@ -151,25 +151,13 @@ async fn main() {
                                 );
                             }
                             if let Some(ref specs) = fmt.technical_specs {
-                                if let Some(ref versions) =
-                                    specs.unreal_engine_engine_versions
-                                {
-                                    println!(
-                                        "    Engine versions: {}",
-                                        versions.join(", ")
-                                    );
+                                if let Some(ref versions) = specs.unreal_engine_engine_versions {
+                                    println!("    Engine versions: {}", versions.join(", "));
                                 }
-                                if let Some(ref platforms) =
-                                    specs.unreal_engine_target_platforms
-                                {
-                                    println!(
-                                        "    Platforms: {}",
-                                        platforms.join(", ")
-                                    );
+                                if let Some(ref platforms) = specs.unreal_engine_target_platforms {
+                                    println!("    Platforms: {}", platforms.join(", "));
                                 }
-                                if let Some(ref method) =
-                                    specs.unreal_engine_distribution_method
-                                {
+                                if let Some(ref method) = specs.unreal_engine_distribution_method {
                                     println!("    Distribution: {}", method);
                                 }
                             }
@@ -186,14 +174,8 @@ async fn main() {
 
                 match egs.fab_listing_state(&first.uid).await {
                     Some(state) => {
-                        println!(
-                            "  Acquired:    {}",
-                            state.acquired.unwrap_or(false)
-                        );
-                        println!(
-                            "  Wishlisted:  {}",
-                            state.wishlisted.unwrap_or(false)
-                        );
+                        println!("  Acquired:    {}", state.acquired.unwrap_or(false));
+                        println!("  Wishlisted:  {}", state.wishlisted.unwrap_or(false));
                         if let Some(ref eid) = state.entitlement_id {
                             println!("  Entitlement: {}", eid);
                         }
@@ -238,10 +220,7 @@ async fn main() {
                             println!("  No pricing info (may be free)");
                         } else {
                             for price in &prices {
-                                let currency = price
-                                    .currency_code
-                                    .as_deref()
-                                    .unwrap_or("?");
+                                let currency = price.currency_code.as_deref().unwrap_or("?");
                                 let amount = price
                                     .price
                                     .map(|p| format!("{:.2}", p))
@@ -271,12 +250,12 @@ async fn main() {
 
                 println!("\n=== Listing Reviews ===\n");
 
-                match egs.fab_listing_reviews(&first.uid, Some("-createdAt"), None).await {
+                match egs
+                    .fab_listing_reviews(&first.uid, Some("-createdAt"), None)
+                    .await
+                {
                     Some(reviews_resp) => {
-                        println!(
-                            "  Total reviews: {}",
-                            reviews_resp.count.unwrap_or(0)
-                        );
+                        println!("  Total reviews: {}", reviews_resp.count.unwrap_or(0));
                         for review in reviews_resp.results.iter().take(3) {
                             let author = review
                                 .user
@@ -287,14 +266,10 @@ async fn main() {
                                 .rating
                                 .map(|r| format!("{}/5", r))
                                 .unwrap_or_else(|| "?".to_string());
-                            let title = review
-                                .title
-                                .as_deref()
-                                .unwrap_or("(no title)");
+                            let title = review.title.as_deref().unwrap_or("(no title)");
                             println!("  [{}] {} — {}", rating, title, author);
                             if let Some(ref content) = review.content {
-                                let preview: String =
-                                    content.chars().take(80).collect();
+                                let preview: String = content.chars().take(80).collect();
                                 if content.len() > 80 {
                                     println!("    {}...", preview);
                                 } else {

--- a/examples/presence.rs
+++ b/examples/presence.rs
@@ -1,8 +1,8 @@
 #[path = "common.rs"]
 mod common;
 
-use egs_api::api::types::presence::{PresenceActivity, PresenceUpdate};
 use egs_api::EpicGames;
+use egs_api::api::types::presence::{PresenceActivity, PresenceUpdate};
 
 #[tokio::main]
 async fn main() {
@@ -16,10 +16,7 @@ async fn main() {
 
     println!("=== Update Presence ===\n");
 
-    let session_id = egs
-        .user_details()
-        .account_id
-        .unwrap_or_default();
+    let session_id = egs.user_details().account_id.unwrap_or_default();
 
     if session_id.is_empty() {
         eprintln!("No access token available for presence update");

--- a/examples/uplay.rs
+++ b/examples/uplay.rs
@@ -38,7 +38,9 @@ async fn main() {
                         );
                     }
                 }
-                None => println!("No Uplay codes found (account may not have Ubisoft-linked games)."),
+                None => {
+                    println!("No Uplay codes found (account may not have Ubisoft-linked games).")
+                }
             }
         }
         Err(e) => eprintln!("Failed to fetch Uplay codes: {:?}", e),

--- a/examples/workflow.rs
+++ b/examples/workflow.rs
@@ -92,7 +92,10 @@ async fn main() {
                     Ok(d) => {
                         println!("Got download manifest from {}", url);
                         println!("Expected Hash: {}", man.manifest_hash);
-                        println!("Download Hash: {}", d.custom_field("DownloadedManifestHash").unwrap_or_default());
+                        println!(
+                            "Download Hash: {}",
+                            d.custom_field("DownloadedManifestHash").unwrap_or_default()
+                        );
                     }
                     Err(_) => {}
                 }

--- a/src/api/account.rs
+++ b/src/api/account.rs
@@ -1,8 +1,8 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::account::{AccountData, AccountInfo, ExternalAuth, TokenVerification};
 use crate::api::types::entitlement::Entitlement;
 use crate::api::types::friends::Friend;
-use crate::api::EpicAPI;
 
 impl EpicAPI {
     /// Fetch account details for the logged-in user.

--- a/src/api/cloud_save.rs
+++ b/src/api/cloud_save.rs
@@ -1,6 +1,6 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::cloud_save::CloudSaveResponse;
-use crate::api::EpicAPI;
 
 impl EpicAPI {
     #[allow(dead_code)]

--- a/src/api/commerce.rs
+++ b/src/api/commerce.rs
@@ -1,8 +1,8 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::billing_account::BillingAccount;
 use crate::api::types::price::PriceResponse;
 use crate::api::types::quick_purchase::QuickPurchaseResponse;
-use crate::api::EpicAPI;
 
 impl EpicAPI {
     /// Fetch offer prices from the price engine.
@@ -18,7 +18,7 @@ impl EpicAPI {
             "offers": offer_ids,
             "country": country,
         });
-        self.authorized_post_json(&url, &body).await
+        self.authorized_post_json(url, &body).await
     }
 
     /// Execute a quick purchase (typically for free game claims).

--- a/src/api/cosmos.rs
+++ b/src/api/cosmos.rs
@@ -1,10 +1,10 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::cosmos::{
-    CosmosAccount, CosmosAuthResponse, CosmosCommOptIn, CosmosEulaResponse, CosmosSearchResults,
-    CosmosPolicyAodc,
+    CosmosAccount, CosmosAuthResponse, CosmosCommOptIn, CosmosEulaResponse, CosmosPolicyAodc,
+    CosmosSearchResults,
 };
 use crate::api::types::engine_blob::EngineBlobsResponse;
-use crate::api::EpicAPI;
 use log::{debug, error, warn};
 use serde::Deserialize;
 
@@ -269,10 +269,7 @@ impl EpicAPI {
     ///
     /// Known settings: `email:ue` (Unreal Engine), likely also `email:fn` (Fortnite).
     /// Requires an active Cosmos session.
-    pub async fn cosmos_comm_opt_in(
-        &self,
-        setting: &str,
-    ) -> Result<CosmosCommOptIn, EpicAPIError> {
+    pub async fn cosmos_comm_opt_in(&self, setting: &str) -> Result<CosmosCommOptIn, EpicAPIError> {
         let url = format!(
             "https://www.unrealengine.com/api/cosmos/communication/opt-in?setting={}",
             setting
@@ -367,13 +364,10 @@ impl EpicAPI {
             })?;
 
         if response.status().is_success() {
-            response
-                .json::<CosmosSearchResults>()
-                .await
-                .map_err(|e| {
-                    error!("Failed to parse cosmos search response: {:?}", e);
-                    EpicAPIError::DeserializationError(format!("{}", e))
-                })
+            response.json::<CosmosSearchResults>().await.map_err(|e| {
+                error!("Failed to parse cosmos search response: {:?}", e);
+                EpicAPIError::DeserializationError(format!("{}", e))
+            })
         } else {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();

--- a/src/api/egs.rs
+++ b/src/api/egs.rs
@@ -1,3 +1,4 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::asset_info::{AssetInfo, GameToken, OwnershipToken};
 use crate::api::types::asset_manifest::AssetManifest;
@@ -7,7 +8,6 @@ use crate::api::types::currency::CurrencyPage;
 use crate::api::types::download_manifest::DownloadManifest;
 use crate::api::types::epic_asset::EpicAsset;
 use crate::api::types::library::Library;
-use crate::api::EpicAPI;
 use log::{debug, error};
 use std::borrow::BorrowMut;
 use std::collections::HashMap;
@@ -21,7 +21,10 @@ impl EpicAPI {
     ) -> Result<Vec<EpicAsset>, EpicAPIError> {
         let plat = platform.unwrap_or_else(|| "Windows".to_string());
         let lab = label.unwrap_or_else(|| "Live".to_string());
-        let url = format!("https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/{}?label={}", plat, lab);
+        let url = format!(
+            "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/{}?label={}",
+            plat, lab
+        );
         self.authorized_get_json(&url).await
     }
 
@@ -43,8 +46,14 @@ impl EpicAPI {
         if app.is_none() {
             return Err(EpicAPIError::InvalidParams);
         };
-        let url = format!("https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/v2/platform/{}/namespace/{}/catalogItem/{}/app/{}/label/{}",
-                          platform.as_deref().unwrap_or("Windows"), namespace.as_deref().unwrap(), item_id.as_deref().unwrap(), app.as_deref().unwrap(), label.as_deref().unwrap_or("Live"));
+        let url = format!(
+            "https://launcher-public-service-prod06.ol.epicgames.com/launcher/api/public/assets/v2/platform/{}/namespace/{}/catalogItem/{}/app/{}/label/{}",
+            platform.as_deref().unwrap_or("Windows"),
+            namespace.as_deref().unwrap(),
+            item_id.as_deref().unwrap(),
+            app.as_deref().unwrap(),
+            label.as_deref().unwrap_or("Live")
+        );
         let mut manifest: AssetManifest = self.authorized_get_json(&url).await?;
         manifest.platform = platform;
         manifest.label = label;
@@ -121,8 +130,10 @@ impl EpicAPI {
         &self,
         asset: &EpicAsset,
     ) -> Result<HashMap<String, AssetInfo>, EpicAPIError> {
-        let url = format!("https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/namespace/{}/bulk/items?id={}&includeDLCDetails=true&includeMainGameDetails=true&country=us&locale=lc",
-                          asset.namespace, asset.catalog_item_id);
+        let url = format!(
+            "https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/namespace/{}/bulk/items?id={}&includeDLCDetails=true&includeMainGameDetails=true&country=us&locale=lc",
+            asset.namespace, asset.catalog_item_id
+        );
         self.authorized_get_json(&url).await
     }
 
@@ -141,8 +152,10 @@ impl EpicAPI {
                 return Err(EpicAPIError::InvalidCredentials);
             }
             Some(id) => {
-                format!("https://ecommerceintegration-public-service-ecomprod02.ol.epicgames.com/ecommerceintegration/api/public/platforms/EPIC/identities/{}/ownershipToken",
-                        id)
+                format!(
+                    "https://ecommerceintegration-public-service-ecomprod02.ol.epicgames.com/ecommerceintegration/api/public/platforms/EPIC/identities/{}/ownershipToken",
+                    id
+                )
             }
         };
         self.authorized_post_form_json(
@@ -230,7 +243,10 @@ impl EpicAPI {
         if old_build_id == new_build_id {
             return None;
         }
-        let url = format!("{}/Deltas/{}/{}.delta", base_url, new_build_id, old_build_id);
+        let url = format!(
+            "{}/Deltas/{}/{}.delta",
+            base_url, new_build_id, old_build_id
+        );
         self.get_bytes(&url).await.ok()
     }
 
@@ -244,10 +260,16 @@ impl EpicAPI {
         loop {
             let url = match &cursor {
                 None => {
-                    format!("https://library-service.live.use1a.on.epicgames.com/library/api/public/items?includeMetadata={}", include_metadata)
+                    format!(
+                        "https://library-service.live.use1a.on.epicgames.com/library/api/public/items?includeMetadata={}",
+                        include_metadata
+                    )
                 }
                 Some(c) => {
-                    format!("https://library-service.live.use1a.on.epicgames.com/library/api/public/items?includeMetadata={}&cursor={}", include_metadata, c)
+                    format!(
+                        "https://library-service.live.use1a.on.epicgames.com/library/api/public/items?includeMetadata={}&cursor={}",
+                        include_metadata, c
+                    )
                 }
             };
 
@@ -331,11 +353,7 @@ impl EpicAPI {
     }
 
     /// Fetch available currencies.
-    pub async fn currencies(
-        &self,
-        start: i64,
-        count: i64,
-    ) -> Result<CurrencyPage, EpicAPIError> {
+    pub async fn currencies(&self, start: i64, count: i64) -> Result<CurrencyPage, EpicAPIError> {
         let url = format!(
             "https://catalog-public-service-prod06.ol.epicgames.com/catalog/api/shared/currencies?start={}&count={}",
             start, count
@@ -344,10 +362,7 @@ impl EpicAPI {
     }
 
     /// Check the status of a library state token.
-    pub async fn library_state_token_status(
-        &self,
-        token_id: &str,
-    ) -> Result<bool, EpicAPIError> {
+    pub async fn library_state_token_status(&self, token_id: &str) -> Result<bool, EpicAPIError> {
         let url = format!(
             "https://library-service.live.use1a.on.epicgames.com/library/api/public/stateToken/{}/status",
             token_id

--- a/src/api/fab.rs
+++ b/src/api/fab.rs
@@ -1,8 +1,8 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::download_manifest::DownloadManifest;
 use crate::api::types::fab_asset_manifest::DownloadInfo;
 use crate::api::types::fab_library::FabLibrary;
-use crate::api::EpicAPI;
 use log::{debug, error, warn};
 use std::borrow::BorrowMut;
 use url::Url;
@@ -185,15 +185,15 @@ impl EpicAPI {
         if let Some(ref in_filter) = params.in_filter {
             query_parts.push(format!("in={}", in_filter));
         }
-        if let Some(is_discounted) = params.is_discounted {
-            if is_discounted {
-                query_parts.push("is_discounted=true".to_string());
-            }
+        if let Some(is_discounted) = params.is_discounted
+            && is_discounted
+        {
+            query_parts.push("is_discounted=true".to_string());
         }
-        if let Some(is_free) = params.is_free {
-            if is_free {
-                query_parts.push("is_free=1".to_string());
-            }
+        if let Some(is_free) = params.is_free
+            && is_free
+        {
+            query_parts.push("is_free=1".to_string());
         }
         if let Some(pct) = params.min_discount_percentage {
             query_parts.push(format!("min_discount_percentage={}", pct));
@@ -311,14 +311,16 @@ impl EpicAPI {
     pub async fn fab_licenses(
         &self,
     ) -> Result<Vec<crate::api::types::fab_taxonomy::FabLicenseType>, EpicAPIError> {
-        self.get_json("https://www.fab.com/i/taxonomy/licenses").await
+        self.get_json("https://www.fab.com/i/taxonomy/licenses")
+            .await
     }
 
     /// Fetch asset format groups. Public endpoint.
     pub async fn fab_format_groups(
         &self,
     ) -> Result<Vec<crate::api::types::fab_taxonomy::FabFormatGroup>, EpicAPIError> {
-        self.get_json("https://www.fab.com/i/taxonomy/asset-format-groups").await
+        self.get_json("https://www.fab.com/i/taxonomy/asset-format-groups")
+            .await
     }
 
     /// Fetch tag groups with nested tags. Public endpoint.
@@ -332,10 +334,9 @@ impl EpicAPI {
     }
 
     /// Fetch available UE versions. Public endpoint.
-    pub async fn fab_ue_versions(
-        &self,
-    ) -> Result<Vec<String>, EpicAPIError> {
-        self.get_json("https://www.fab.com/i/unreal-engine/versions").await
+    pub async fn fab_ue_versions(&self) -> Result<Vec<String>, EpicAPIError> {
+        self.get_json("https://www.fab.com/i/unreal-engine/versions")
+            .await
     }
 
     /// Fetch channel info by slug. Public endpoint.
@@ -401,8 +402,8 @@ impl EpicAPI {
 
     /// Initialize Fab CSRF token. Sets `fab_csrftoken` cookie on the client.
     pub async fn fab_csrf(&self) -> Result<(), EpicAPIError> {
-        let parsed_url =
-            url::Url::parse("https://www.fab.com/i/csrf").map_err(|_| EpicAPIError::InvalidParams)?;
+        let parsed_url = url::Url::parse("https://www.fab.com/i/csrf")
+            .map_err(|_| EpicAPIError::InvalidParams)?;
         let response = Self::send(self.client.get(parsed_url)).await?;
         if response.status().is_success() {
             Ok(())

--- a/src/api/login.rs
+++ b/src/api/login.rs
@@ -1,8 +1,8 @@
-use log::{error, info, warn};
-use reqwest::Response;
 use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::account::UserData;
+use log::{error, info, warn};
+use reqwest::Response;
 
 impl EpicAPI {
     /// Start a new OAuth session with exchange token, authorization code, or refresh token.
@@ -83,12 +83,12 @@ impl EpicAPI {
     /// Resume an existing session by verifying the access token.
     pub async fn resume_session(&mut self) -> Result<bool, EpicAPIError> {
         let url = "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/verify";
-        match self.authorized_get_client(
-            url::Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?
-        ).send().await {
-            Ok(response) => {
-                self.handle_login_response(response).await
-            }
+        match self
+            .authorized_get_client(url::Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?)
+            .send()
+            .await
+        {
+            Ok(response) => self.handle_login_response(response).await,
             Err(e) => {
                 error!("{:?}", e);
                 Err(EpicAPIError::NetworkError(e))
@@ -127,10 +127,7 @@ impl EpicAPI {
     /// Performs the web-based exchange: set-sid -> csrf -> exchange/generate,
     /// then uses the resulting exchange code to start a session.
     pub async fn auth_sid(&mut self, sid: &str) -> Result<bool, EpicAPIError> {
-        let set_sid_url = format!(
-            "https://www.epicgames.com/id/api/set-sid?sid={}",
-            sid
-        );
+        let set_sid_url = format!("https://www.epicgames.com/id/api/set-sid?sid={}", sid);
         self.client
             .get(&set_sid_url)
             .header(
@@ -188,9 +185,7 @@ impl EpicAPI {
                 EpicAPIError::DeserializationError(format!("{}", e))
             })?;
 
-        let code = exchange_data
-            .code
-            .ok_or(EpicAPIError::InvalidCredentials)?;
+        let code = exchange_data.code.ok_or(EpicAPIError::InvalidCredentials)?;
 
         self.start_session(Some(code), None).await
     }
@@ -198,7 +193,10 @@ impl EpicAPI {
     /// Invalidate the current session (note: method name has a known typo).
     pub async fn invalidate_sesion(&mut self) -> bool {
         if let Some(access_token) = &self.user_data.access_token {
-            let url = format!("https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/sessions/kill/{}", access_token);
+            let url = format!(
+                "https://account-public-service-prod03.ol.epicgames.com/account/api/oauth/sessions/kill/{}",
+                access_token
+            );
             match self.client.delete(&url).send().await {
                 Ok(_) => {
                     info!("Session invalidated");

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -26,11 +26,11 @@ pub mod fab;
 ///Account methods
 pub mod account;
 
-/// EGS Methods
-pub mod egs;
 #[allow(dead_code)]
 /// Cloud Save Methods
 pub mod cloud_save;
+/// EGS Methods
+pub mod egs;
 /// Session Handling
 pub mod login;
 
@@ -201,10 +201,7 @@ impl EpicAPI {
         }
     }
 
-    pub(crate) async fn get_json<T: DeserializeOwned>(
-        &self,
-        url: &str,
-    ) -> Result<T, EpicAPIError> {
+    pub(crate) async fn get_json<T: DeserializeOwned>(&self, url: &str) -> Result<T, EpicAPIError> {
         let parsed_url = Url::parse(url).map_err(|_| EpicAPIError::InvalidParams)?;
         debug!("get_json: {}", url);
         Self::send_and_deserialize(self.client.get(parsed_url), url).await

--- a/src/api/presence.rs
+++ b/src/api/presence.rs
@@ -1,6 +1,6 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::presence::PresenceUpdate;
-use crate::api::EpicAPI;
 
 impl EpicAPI {
     /// Update user presence status.

--- a/src/api/status.rs
+++ b/src/api/status.rs
@@ -1,6 +1,6 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::service_status::ServiceStatus;
-use crate::api::EpicAPI;
 
 impl EpicAPI {
     /// Fetch bulk service status from the lightswitch API.

--- a/src/api/store.rs
+++ b/src/api/store.rs
@@ -1,8 +1,8 @@
+use crate::api::EpicAPI;
 use crate::api::error::EpicAPIError;
 use crate::api::types::uplay::{
     UplayClaimResult, UplayCodesResult, UplayGraphQLResponse, UplayRedeemResult,
 };
-use crate::api::EpicAPI;
 use log::error;
 
 const UPLAY_CODES_QUERY: &str = r#"
@@ -132,8 +132,7 @@ impl EpicAPI {
         &self,
         body: &serde_json::Value,
     ) -> Result<T, EpicAPIError> {
-        let parsed_url =
-            url::Url::parse(STORE_GQL_URL).map_err(|_| EpicAPIError::InvalidParams)?;
+        let parsed_url = url::Url::parse(STORE_GQL_URL).map_err(|_| EpicAPIError::InvalidParams)?;
         let response = self
             .set_authorization_header(self.client.post(parsed_url))
             .header("User-Agent", STORE_USER_AGENT)

--- a/src/api/types/asset_info.rs
+++ b/src/api/types/asset_info.rs
@@ -46,10 +46,10 @@ pub struct AssetInfo {
 impl AssetInfo {
     /// Get the latest release by release_date
     pub fn latest_release(&self) -> Option<ReleaseInfo> {
-        if let Some(releases) = self.sorted_releases() {
-            if let Some(rel) = releases.first() {
-                return Some(rel.clone());
-            }
+        if let Some(releases) = self.sorted_releases()
+            && let Some(rel) = releases.first()
+        {
+            return Some(rel.clone());
         }
         None
     }

--- a/src/api/types/chunk.rs
+++ b/src/api/types/chunk.rs
@@ -80,8 +80,8 @@ impl Chunk {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use flate2::write::ZlibEncoder;
     use flate2::Compression;
+    use flate2::write::ZlibEncoder;
     use std::io::Write;
 
     #[test]
@@ -109,7 +109,7 @@ mod tests {
         assert!(chunk.guid.starts_with("00000000"));
         assert_eq!(chunk.hash, 42);
         assert_eq!(chunk.data, vec![1, 2, 3, 4, 5]);
-        assert_eq!(chunk.compressed, false);
+        assert!(!chunk.compressed);
     }
 
     #[test]

--- a/src/api/types/download_manifest.rs
+++ b/src/api/types/download_manifest.rs
@@ -1,10 +1,10 @@
 use crate::api::binary_rw::{BinaryReader, BinaryWriter};
+use flate2::Compression;
 use flate2::read::ZlibDecoder;
 use flate2::write::ZlibEncoder;
-use flate2::Compression;
 use log::{debug, error, warn};
 use reqwest::Url;
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use sha1::{Digest, Sha1};
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};

--- a/src/api/types/fab_asset_manifest.rs
+++ b/src/api/types/fab_asset_manifest.rs
@@ -93,16 +93,18 @@ mod tests {
     #[test]
     fn get_distribution_point_by_base_url_not_found() {
         let di = make_download_info(vec!["https://cdn1.example.com/manifest.json"]);
-        assert!(di
-            .get_distribution_point_by_base_url("https://cdn3")
-            .is_none());
+        assert!(
+            di.get_distribution_point_by_base_url("https://cdn3")
+                .is_none()
+        );
     }
 
     #[test]
     fn get_distribution_point_by_base_url_empty() {
         let di = make_download_info(vec![]);
-        assert!(di
-            .get_distribution_point_by_base_url("https://anything")
-            .is_none());
+        assert!(
+            di.get_distribution_point_by_base_url("https://anything")
+                .is_none()
+        );
     }
 }

--- a/src/api/types/fab_library.rs
+++ b/src/api/types/fab_library.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 use serde_with::DefaultOnNull;
+use serde_with::serde_as;
 
 /// Fab Library Response
 #[derive(Default, Debug, Clone, PartialEq, Serialize, Deserialize)]

--- a/src/api/utils.rs
+++ b/src/api/utils.rs
@@ -114,14 +114,14 @@ mod tests {
     fn vector_match() {
         let a = vec![0, 0, 0];
         let b = vec![0, 0, 0];
-        assert_eq!(do_vecs_match(&a, &b), true);
+        assert!(do_vecs_match(&a, &b));
     }
 
     #[test]
     fn vector_not_match() {
         let a = vec![0, 0, 0];
         let b = vec![0, 0, 1];
-        assert_eq!(do_vecs_match(&a, &b), false);
+        assert!(!do_vecs_match(&a, &b));
     }
 
     #[test]

--- a/src/facade/account.rs
+++ b/src/facade/account.rs
@@ -1,3 +1,4 @@
+use crate::EpicGames;
 use crate::api::error::EpicAPIError;
 use crate::api::types::account::{AccountData, AccountInfo, ExternalAuth};
 use crate::api::types::asset_info::GameToken;
@@ -5,7 +6,6 @@ use crate::api::types::entitlement::Entitlement;
 use crate::api::types::epic_asset::EpicAsset;
 use crate::api::types::friends::Friend;
 use crate::api::types::library::Library;
-use crate::EpicGames;
 
 impl EpicGames {
     /// Like [`account_details`](Self::account_details), but returns a `Result` instead of swallowing errors.
@@ -51,7 +51,10 @@ impl EpicGames {
     }
 
     /// Like [`external_auths`](Self::external_auths), but returns a `Result` instead of swallowing errors.
-    pub async fn try_external_auths(&self, account_id: &str) -> Result<Vec<ExternalAuth>, EpicAPIError> {
+    pub async fn try_external_auths(
+        &self,
+        account_id: &str,
+    ) -> Result<Vec<ExternalAuth>, EpicAPIError> {
         self.egs.external_auths(account_id).await
     }
 
@@ -113,11 +116,16 @@ impl EpicGames {
     ///
     /// Returns empty `Vec` on API errors.
     pub async fn user_entitlements(&mut self) -> Vec<Entitlement> {
-        self.try_user_entitlements().await.unwrap_or_else(|_| Vec::new())
+        self.try_user_entitlements()
+            .await
+            .unwrap_or_else(|_| Vec::new())
     }
 
     /// Like [`library_items`](Self::library_items), but returns a `Result` instead of swallowing errors.
-    pub async fn try_library_items(&mut self, include_metadata: bool) -> Result<Library, EpicAPIError> {
+    pub async fn try_library_items(
+        &mut self,
+        include_metadata: bool,
+    ) -> Result<Library, EpicAPIError> {
         self.egs.library_items(include_metadata).await
     }
 

--- a/src/facade/assets.rs
+++ b/src/facade/assets.rs
@@ -1,11 +1,11 @@
+use crate::EpicGames;
 use crate::api::error::EpicAPIError;
+use crate::api::types::artifact_service::ArtifactServiceTicket;
 use crate::api::types::asset_info::AssetInfo;
 use crate::api::types::asset_manifest::AssetManifest;
-use crate::api::types::artifact_service::ArtifactServiceTicket;
 use crate::api::types::download_manifest::DownloadManifest;
 use crate::api::types::engine_blob;
 use crate::api::types::epic_asset::EpicAsset;
-use crate::EpicGames;
 
 impl EpicGames {
     /// Like [`list_assets`](Self::list_assets), but returns a `Result` instead of swallowing errors.

--- a/src/facade/auth.rs
+++ b/src/facade/auth.rs
@@ -1,6 +1,6 @@
+use crate::EpicGames;
 use crate::api::error::EpicAPIError;
 use crate::api::types::account::{TokenVerification, UserData};
-use crate::EpicGames;
 use log::{error, info, warn};
 
 impl EpicGames {

--- a/src/facade/cosmos.rs
+++ b/src/facade/cosmos.rs
@@ -1,6 +1,6 @@
+use crate::EpicGames;
 use crate::api::error::EpicAPIError;
 use crate::api::types::cosmos;
-use crate::EpicGames;
 
 impl EpicGames {
     /// Set up a Cosmos cookie session from an exchange code.
@@ -13,9 +13,7 @@ impl EpicGames {
     }
 
     /// Upgrade bearer token to Cosmos session (step 5 of session setup).
-    pub async fn cosmos_auth_upgrade(
-        &self,
-    ) -> Result<cosmos::CosmosAuthResponse, EpicAPIError> {
+    pub async fn cosmos_auth_upgrade(&self) -> Result<cosmos::CosmosAuthResponse, EpicAPIError> {
         self.egs.cosmos_auth_upgrade().await
     }
 
@@ -77,17 +75,12 @@ impl EpicGames {
     }
 
     /// Check Age of Digital Consent policy. Returns full `Result`.
-    pub async fn try_cosmos_policy_aodc(
-        &self,
-    ) -> Result<cosmos::CosmosPolicyAodc, EpicAPIError> {
+    pub async fn try_cosmos_policy_aodc(&self) -> Result<cosmos::CosmosPolicyAodc, EpicAPIError> {
         self.egs.cosmos_policy_aodc().await
     }
 
     /// Check communication opt-in status. Returns `None` on error.
-    pub async fn cosmos_comm_opt_in(
-        &self,
-        setting: &str,
-    ) -> Option<cosmos::CosmosCommOptIn> {
+    pub async fn cosmos_comm_opt_in(&self, setting: &str) -> Option<cosmos::CosmosCommOptIn> {
         self.egs.cosmos_comm_opt_in(setting).await.ok()
     }
 
@@ -109,7 +102,9 @@ impl EpicGames {
         locale: Option<&str>,
         filter: Option<&str>,
     ) -> Option<cosmos::CosmosSearchResults> {
-        self.try_cosmos_search(query, slug, locale, filter).await.ok()
+        self.try_cosmos_search(query, slug, locale, filter)
+            .await
+            .ok()
     }
 
     /// Like [`cosmos_search`](Self::cosmos_search), but returns a `Result` instead of swallowing errors.

--- a/src/facade/fab.rs
+++ b/src/facade/fab.rs
@@ -1,10 +1,10 @@
+use crate::EpicGames;
 use crate::api::error::EpicAPIError;
 use crate::api::types::download_manifest::DownloadManifest;
 use crate::api::types::fab_asset_manifest::DownloadInfo;
 use crate::api::types::fab_entitlement;
 use crate::api::types::fab_search;
 use crate::api::types::fab_taxonomy;
-use crate::EpicGames;
 
 impl EpicGames {
     /// Fetch Fab asset manifest with signed distribution points.
@@ -137,10 +137,7 @@ impl EpicGames {
     }
 
     /// Get listing state (ownership, wishlist, review). Returns `None` on error.
-    pub async fn fab_listing_state(
-        &self,
-        uid: &str,
-    ) -> Option<fab_search::FabListingState> {
+    pub async fn fab_listing_state(&self, uid: &str) -> Option<fab_search::FabListingState> {
         self.egs.fab_listing_state(uid).await.ok()
     }
 
@@ -185,10 +182,7 @@ impl EpicGames {
     }
 
     /// Get listing ownership info. Returns `None` on error.
-    pub async fn fab_listing_ownership(
-        &self,
-        uid: &str,
-    ) -> Option<fab_search::FabOwnership> {
+    pub async fn fab_listing_ownership(&self, uid: &str) -> Option<fab_search::FabOwnership> {
         self.egs.fab_listing_ownership(uid).await.ok()
     }
 
@@ -201,10 +195,7 @@ impl EpicGames {
     }
 
     /// Get pricing for a specific listing. Returns `None` on error.
-    pub async fn fab_listing_prices(
-        &self,
-        uid: &str,
-    ) -> Option<Vec<fab_search::FabPriceInfo>> {
+    pub async fn fab_listing_prices(&self, uid: &str) -> Option<Vec<fab_search::FabPriceInfo>> {
         self.egs.fab_listing_prices(uid).await.ok()
     }
 
@@ -223,7 +214,10 @@ impl EpicGames {
         sort_by: Option<&str>,
         cursor: Option<&str>,
     ) -> Option<fab_search::FabReviewsResponse> {
-        self.egs.fab_listing_reviews(uid, sort_by, cursor).await.ok()
+        self.egs
+            .fab_listing_reviews(uid, sort_by, cursor)
+            .await
+            .ok()
     }
 
     /// Get reviews for a listing. Returns full `Result`.
@@ -268,9 +262,7 @@ impl EpicGames {
     }
 
     /// Fetch tag groups with nested tags. Returns full `Result`.
-    pub async fn try_fab_tag_groups(
-        &self,
-    ) -> Result<Vec<fab_taxonomy::FabTagGroup>, EpicAPIError> {
+    pub async fn try_fab_tag_groups(&self) -> Result<Vec<fab_taxonomy::FabTagGroup>, EpicAPIError> {
         self.egs.fab_tag_groups().await
     }
 
@@ -328,9 +320,7 @@ impl EpicGames {
     }
 
     /// Fetch Fab user context. Returns full `Result`.
-    pub async fn try_fab_user_context(
-        &self,
-    ) -> Result<fab_search::FabUserContext, EpicAPIError> {
+    pub async fn try_fab_user_context(&self) -> Result<fab_search::FabUserContext, EpicAPIError> {
         self.egs.fab_user_context().await
     }
 

--- a/src/facade/misc.rs
+++ b/src/facade/misc.rs
@@ -1,8 +1,8 @@
+use crate::EpicGames;
 use crate::api::error::EpicAPIError;
 use crate::api::types::cloud_save::CloudSaveResponse;
 use crate::api::types::presence::PresenceUpdate;
 use crate::api::types::service_status::ServiceStatus;
-use crate::EpicGames;
 
 impl EpicGames {
     /// Like [`service_status`](Self::service_status), but returns a `Result` instead of swallowing errors.

--- a/src/facade/mod.rs
+++ b/src/facade/mod.rs
@@ -1,14 +1,14 @@
-/// Authentication facade methods
-mod auth;
-/// Asset and manifest facade methods
-mod assets;
 /// Account, social, and entitlement facade methods
 mod account;
-/// Fab marketplace facade methods
-mod fab;
-/// Store, catalog, and commerce facade methods
-mod store;
+/// Asset and manifest facade methods
+mod assets;
+/// Authentication facade methods
+mod auth;
 /// Cosmos / Unreal Engine facade methods
 mod cosmos;
+/// Fab marketplace facade methods
+mod fab;
 /// Miscellaneous facade methods (presence, cloud saves, service status)
 mod misc;
+/// Store, catalog, and commerce facade methods
+mod store;

--- a/src/facade/store.rs
+++ b/src/facade/store.rs
@@ -1,3 +1,4 @@
+use crate::EpicGames;
 use crate::api::error::EpicAPIError;
 use crate::api::types::asset_info::AssetInfo;
 use crate::api::types::billing_account::BillingAccount;
@@ -9,7 +10,6 @@ use crate::api::types::quick_purchase::QuickPurchaseResponse;
 use crate::api::types::uplay::{
     UplayClaimResult, UplayCodesResult, UplayGraphQLResponse, UplayRedeemResult,
 };
-use crate::EpicGames;
 
 impl EpicGames {
     /// Like [`catalog_items`](Self::catalog_items), but returns a `Result` instead of swallowing errors.
@@ -69,7 +69,10 @@ impl EpicGames {
     pub async fn try_bulk_catalog_items(
         &self,
         items: &[(&str, &str)],
-    ) -> Result<std::collections::HashMap<String, std::collections::HashMap<String, AssetInfo>>, EpicAPIError> {
+    ) -> Result<
+        std::collections::HashMap<String, std::collections::HashMap<String, AssetInfo>>,
+        EpicAPIError,
+    > {
         self.egs.bulk_catalog_items(items).await
     }
 
@@ -83,12 +86,17 @@ impl EpicGames {
     pub async fn bulk_catalog_items(
         &self,
         items: &[(&str, &str)],
-    ) -> Option<std::collections::HashMap<String, std::collections::HashMap<String, AssetInfo>>> {
+    ) -> Option<std::collections::HashMap<String, std::collections::HashMap<String, AssetInfo>>>
+    {
         self.try_bulk_catalog_items(items).await.ok()
     }
 
     /// Like [`currencies`](Self::currencies), but returns a `Result` instead of swallowing errors.
-    pub async fn try_currencies(&self, start: i64, count: i64) -> Result<CurrencyPage, EpicAPIError> {
+    pub async fn try_currencies(
+        &self,
+        start: i64,
+        count: i64,
+    ) -> Result<CurrencyPage, EpicAPIError> {
         self.egs.currencies(start, count).await
     }
 
@@ -144,7 +152,9 @@ impl EpicGames {
         offer_ids: &[String],
         country: &str,
     ) -> Option<PriceResponse> {
-        self.try_offer_prices(namespace, offer_ids, country).await.ok()
+        self.try_offer_prices(namespace, offer_ids, country)
+            .await
+            .ok()
     }
 
     /// Like [`quick_purchase`](Self::quick_purchase), but returns a `Result` instead of swallowing errors.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -154,7 +154,10 @@ mod facade_tests {
         let mut ud = UserData::new();
         ud.display_name = Some("TestUser".to_string());
         egs.set_user_details(ud);
-        assert_eq!(egs.user_details().display_name, Some("TestUser".to_string()));
+        assert_eq!(
+            egs.user_details().display_name,
+            Some("TestUser".to_string())
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- **Upgrade CI workflow** — Replace minimal build+test with comprehensive pipeline:
  - `actions/checkout@v2` → `v4`, `dtolnay/rust-toolchain@stable`
  - Clippy with `-D warnings` (fixes 4 pre-existing warnings)
  - Rustfmt check
  - `Swatinem/rust-cache` for faster builds
  - Auto-publish to crates.io on `v*` tags
  - Fix push trigger: `main` → `master` (matches default branch)
- **Bump edition 2021 → 2024**, drop `rust-version` (use latest stable)
- **Add rustfmt pre-commit hook** — `.githooks/pre-commit` checks staged `.rs` files. Enable with `git config core.hooksPath .githooks`

## Setup required

Add a `CARGO_REGISTRY_TOKEN` secret in repo Settings → Secrets → Actions for the publish job. Then tag releases with:

```bash
git tag v0.14.0
git push origin v0.14.0
```